### PR TITLE
Clean up Resource initialization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.treescrub</groupId>
     <artifactId>spedran</artifactId>
-    <version>0.13.0</version>
+    <version>0.14.0</version>
     <packaging>jar</packaging>
 
     <name>Spedran</name>

--- a/src/main/java/com/github/treescrub/spedran/data/Developer.java
+++ b/src/main/java/com/github/treescrub/spedran/data/Developer.java
@@ -1,7 +1,5 @@
 package com.github.treescrub.spedran.data;
 
-import kong.unirest.HttpResponse;
-import kong.unirest.JsonNode;
 import kong.unirest.json.JSONObject;
 
 /**
@@ -9,17 +7,8 @@ import kong.unirest.json.JSONObject;
  */
 public class Developer extends IdentifiableNamedResource {
 
-    public Developer(HttpResponse<JsonNode> data) {
-        super(data);
-    }
-
     public Developer(JSONObject data) {
         super(data);
-    }
-
-    @Override
-    protected void parseFromJson(JSONObject data) {
-        super.parseFromJson(data);
     }
 
     @Override

--- a/src/main/java/com/github/treescrub/spedran/data/Engine.java
+++ b/src/main/java/com/github/treescrub/spedran/data/Engine.java
@@ -1,7 +1,5 @@
 package com.github.treescrub.spedran.data;
 
-import kong.unirest.HttpResponse;
-import kong.unirest.JsonNode;
 import kong.unirest.json.JSONObject;
 
 /**
@@ -9,17 +7,8 @@ import kong.unirest.json.JSONObject;
  */
 public class Engine extends IdentifiableNamedResource {
 
-    public Engine(HttpResponse<JsonNode> data) {
-        super(data);
-    }
-
     public Engine(JSONObject data) {
         super(data);
-    }
-
-    @Override
-    protected void parseFromJson(JSONObject data) {
-        super.parseFromJson(data);
     }
 
     @Override

--- a/src/main/java/com/github/treescrub/spedran/data/Gametype.java
+++ b/src/main/java/com/github/treescrub/spedran/data/Gametype.java
@@ -1,7 +1,5 @@
 package com.github.treescrub.spedran.data;
 
-import kong.unirest.HttpResponse;
-import kong.unirest.JsonNode;
 import kong.unirest.json.JSONObject;
 
 /**
@@ -11,17 +9,8 @@ import kong.unirest.json.JSONObject;
  */
 public class Gametype extends IdentifiableNamedResource {
 
-    public Gametype(HttpResponse<JsonNode> data) {
-        super(data);
-    }
-
     public Gametype(JSONObject data) {
         super(data);
-    }
-
-    @Override
-    protected void parseFromJson(JSONObject data) {
-        super.parseFromJson(data);
     }
 
     @Override

--- a/src/main/java/com/github/treescrub/spedran/data/Genre.java
+++ b/src/main/java/com/github/treescrub/spedran/data/Genre.java
@@ -1,7 +1,5 @@
 package com.github.treescrub.spedran.data;
 
-import kong.unirest.HttpResponse;
-import kong.unirest.JsonNode;
 import kong.unirest.json.JSONObject;
 
 /**
@@ -11,17 +9,8 @@ import kong.unirest.json.JSONObject;
  */
 public class Genre extends IdentifiableNamedResource {
 
-    public Genre(HttpResponse<JsonNode> data) {
-        super(data);
-    }
-
     public Genre(JSONObject data) {
         super(data);
-    }
-
-    @Override
-    protected void parseFromJson(JSONObject data) {
-        super.parseFromJson(data);
     }
 
     @Override

--- a/src/main/java/com/github/treescrub/spedran/data/Guest.java
+++ b/src/main/java/com/github/treescrub/spedran/data/Guest.java
@@ -1,7 +1,5 @@
 package com.github.treescrub.spedran.data;
 
-import kong.unirest.HttpResponse;
-import kong.unirest.JsonNode;
 import kong.unirest.json.JSONObject;
 
 import java.util.Objects;
@@ -10,18 +8,11 @@ import java.util.Objects;
  * A guest runner. Can be entered as a runner in a run by other users, but has no account.
  */
 public class Guest extends Resource {
-    private String name;
-
-    public Guest(HttpResponse<JsonNode> data) {
-        super(data);
-    }
+    private final String name;
 
     public Guest(JSONObject data) {
         super(data);
-    }
 
-    @Override
-    protected void parseFromJson(JSONObject data) {
         name = data.getString("name");
     }
 

--- a/src/main/java/com/github/treescrub/spedran/data/IdentifiableNamedResource.java
+++ b/src/main/java/com/github/treescrub/spedran/data/IdentifiableNamedResource.java
@@ -15,13 +15,6 @@ public abstract class IdentifiableNamedResource extends IdentifiableResource {
         super(data);
     }
 
-    @Override
-    protected void parseFromJson(JSONObject data) {
-        super.parseFromJson(data);
-
-        name = data.getString("name");
-    }
-
     /**
      * Gets the name for this resource.
      *

--- a/src/main/java/com/github/treescrub/spedran/data/IdentifiableNamedResource.java
+++ b/src/main/java/com/github/treescrub/spedran/data/IdentifiableNamedResource.java
@@ -1,18 +1,14 @@
 package com.github.treescrub.spedran.data;
 
-import kong.unirest.HttpResponse;
-import kong.unirest.JsonNode;
 import kong.unirest.json.JSONObject;
 
 public abstract class IdentifiableNamedResource extends IdentifiableResource {
-    protected String name;
-
-    public IdentifiableNamedResource(HttpResponse<JsonNode> data) {
-        super(data);
-    }
+    protected final String name;
 
     public IdentifiableNamedResource(JSONObject data) {
         super(data);
+
+        name = data.getString("name");
     }
 
     /**

--- a/src/main/java/com/github/treescrub/spedran/data/IdentifiableResource.java
+++ b/src/main/java/com/github/treescrub/spedran/data/IdentifiableResource.java
@@ -1,20 +1,16 @@
 package com.github.treescrub.spedran.data;
 
-import kong.unirest.HttpResponse;
-import kong.unirest.JsonNode;
 import kong.unirest.json.JSONObject;
 
 import java.util.Objects;
 
 public abstract class IdentifiableResource extends Resource {
-    protected String id;
-
-    public IdentifiableResource(HttpResponse<JsonNode> data) {
-        super(data);
-    }
+    protected final String id;
 
     public IdentifiableResource(JSONObject data) {
         super(data);
+
+        id = data.getString("id");
     }
 
     /**

--- a/src/main/java/com/github/treescrub/spedran/data/IdentifiableResource.java
+++ b/src/main/java/com/github/treescrub/spedran/data/IdentifiableResource.java
@@ -17,11 +17,6 @@ public abstract class IdentifiableResource extends Resource {
         super(data);
     }
 
-    @Override
-    protected void parseFromJson(JSONObject data) {
-        id = data.getString("id");
-    }
-
     /**
      * Gets the ID for this resource.
      *

--- a/src/main/java/com/github/treescrub/spedran/data/Level.java
+++ b/src/main/java/com/github/treescrub/spedran/data/Level.java
@@ -3,8 +3,6 @@ package com.github.treescrub.spedran.data;
 import com.github.treescrub.spedran.api.request.level.LevelCategoriesRequest;
 import com.github.treescrub.spedran.api.request.level.LevelRecordsRequest;
 import com.github.treescrub.spedran.api.request.level.LevelVariablesRequest;
-import kong.unirest.HttpResponse;
-import kong.unirest.JsonNode;
 import kong.unirest.json.JSONObject;
 
 import java.util.Optional;
@@ -13,15 +11,14 @@ import java.util.Optional;
  * A specific level in a {@link com.github.treescrub.spedran.data.game.Game}.
  */
 public class Level extends IdentifiableNamedResource {
-    private String weblink;
-    private String rules;
-
-    public Level(HttpResponse<JsonNode> data) {
-        super(data);
-    }
+    private final String weblink;
+    private final String rules;
 
     public Level(JSONObject data) {
         super(data);
+
+        weblink = data.getString("weblink");
+        rules = data.optString("rules", null);
     }
 
     /**
@@ -49,14 +46,6 @@ public class Level extends IdentifiableNamedResource {
      */
     public LevelVariablesRequest getVariables() {
         return new LevelVariablesRequest(this);
-    }
-
-    @Override
-    protected void parseFromJson(JSONObject data) {
-        super.parseFromJson(data);
-
-        weblink = data.getString("weblink");
-        rules = data.optString("rules", null);
     }
 
     /**

--- a/src/main/java/com/github/treescrub/spedran/data/Link.java
+++ b/src/main/java/com/github/treescrub/spedran/data/Link.java
@@ -1,7 +1,5 @@
 package com.github.treescrub.spedran.data;
 
-import kong.unirest.HttpResponse;
-import kong.unirest.JsonNode;
 import kong.unirest.json.JSONObject;
 
 import java.util.Optional;
@@ -10,21 +8,12 @@ import java.util.Optional;
  * A link consisting of a URI and optionally a relation.
  */
 public class Link {
-    private String uri;
-    private String rel;
-
-    public Link(HttpResponse<JsonNode> data) {
-        this(data.getBody().getObject().getJSONObject("data"));
-    }
+    private final String uri;
+    private final String rel;
 
     public Link(JSONObject data) {
-        parseFromJson(data);
-    }
-
-    private void parseFromJson(JSONObject data) {
         uri = data.getString("uri");
-        if(data.has("rel"))
-            rel = data.getString("rel");
+        rel = data.optString("rel", null);
     }
 
     /**

--- a/src/main/java/com/github/treescrub/spedran/data/Names.java
+++ b/src/main/java/com/github/treescrub/spedran/data/Names.java
@@ -1,7 +1,5 @@
 package com.github.treescrub.spedran.data;
 
-import kong.unirest.HttpResponse;
-import kong.unirest.JsonNode;
 import kong.unirest.json.JSONObject;
 
 import java.util.Optional;
@@ -10,19 +8,11 @@ import java.util.Optional;
  * Contains international, Japanese, and Twitch names.
  */
 public class Names {
-    private String international;
-    private String japanese;
-    private String twitch;
-
-    public Names(HttpResponse<JsonNode> data) {
-        this(data.getBody().getObject().getJSONObject("data"));
-    }
+    private final String international;
+    private final String japanese;
+    private final String twitch;
 
     public Names(JSONObject data) {
-        parseFromJson(data);
-    }
-
-    private void parseFromJson(JSONObject data) {
         international = data.getString("international");
         japanese = data.optString("japanese", null);
         twitch = data.optString("twitch", null);

--- a/src/main/java/com/github/treescrub/spedran/data/Platform.java
+++ b/src/main/java/com/github/treescrub/spedran/data/Platform.java
@@ -1,7 +1,5 @@
 package com.github.treescrub.spedran.data;
 
-import kong.unirest.HttpResponse;
-import kong.unirest.JsonNode;
 import kong.unirest.json.JSONObject;
 
 /**
@@ -10,19 +8,10 @@ import kong.unirest.json.JSONObject;
  * For example: PC, Xbox 360, Game Boy Advance, Amazon Fire TV, and so on.
  */
 public class Platform extends IdentifiableNamedResource {
-    private int released;
-
-    public Platform(HttpResponse<JsonNode> data) {
-        super(data);
-    }
+    private final int released;
 
     public Platform(JSONObject data) {
         super(data);
-    }
-
-    @Override
-    protected void parseFromJson(JSONObject data) {
-        super.parseFromJson(data);
 
         released = data.getInt("released");
     }

--- a/src/main/java/com/github/treescrub/spedran/data/Publisher.java
+++ b/src/main/java/com/github/treescrub/spedran/data/Publisher.java
@@ -1,7 +1,5 @@
 package com.github.treescrub.spedran.data;
 
-import kong.unirest.HttpResponse;
-import kong.unirest.JsonNode;
 import kong.unirest.json.JSONObject;
 
 /**
@@ -11,17 +9,8 @@ import kong.unirest.json.JSONObject;
  */
 public class Publisher extends IdentifiableNamedResource {
 
-    public Publisher(HttpResponse<JsonNode> data) {
-        super(data);
-    }
-
     public Publisher(JSONObject data) {
         super(data);
-    }
-
-    @Override
-    protected void parseFromJson(JSONObject data) {
-        super.parseFromJson(data);
     }
 
     @Override

--- a/src/main/java/com/github/treescrub/spedran/data/Region.java
+++ b/src/main/java/com/github/treescrub/spedran/data/Region.java
@@ -1,7 +1,5 @@
 package com.github.treescrub.spedran.data;
 
-import kong.unirest.HttpResponse;
-import kong.unirest.JsonNode;
 import kong.unirest.json.JSONObject;
 
 /**
@@ -13,17 +11,8 @@ import kong.unirest.json.JSONObject;
  */
 public class Region extends IdentifiableNamedResource {
 
-    public Region(HttpResponse<JsonNode> data) {
-        super(data);
-    }
-
     public Region(JSONObject data) {
         super(data);
-    }
-
-    @Override
-    protected void parseFromJson(JSONObject data) {
-        super.parseFromJson(data);
     }
 
     @Override

--- a/src/main/java/com/github/treescrub/spedran/data/Resource.java
+++ b/src/main/java/com/github/treescrub/spedran/data/Resource.java
@@ -9,11 +9,5 @@ public abstract class Resource {
         this(data.getBody().getObject().getJSONObject("data"));
     }
 
-    public Resource(JSONObject data) {
-        parseFromJson(data);
-    }
-
-    protected Resource() {}
-
-    protected abstract void parseFromJson(JSONObject data);
+    public Resource(JSONObject data) {}
 }

--- a/src/main/java/com/github/treescrub/spedran/data/Series.java
+++ b/src/main/java/com/github/treescrub/spedran/data/Series.java
@@ -1,8 +1,6 @@
 package com.github.treescrub.spedran.data;
 
 import com.github.treescrub.spedran.api.request.series.SeriesGamesRequest;
-import kong.unirest.HttpResponse;
-import kong.unirest.JsonNode;
 import kong.unirest.json.JSONObject;
 
 import java.time.Instant;
@@ -19,19 +17,30 @@ import java.util.Optional;
  * The special series named {@code N/A} is a placeholder when a game is not part of a series.
  */
 public class Series extends IdentifiableResource {
-    private Names names;
-    private String abbreviation;
-    private String weblink;
-    private String discord;
-    private Map<String, String> moderators;
-    private Instant created;
-
-    public Series(HttpResponse<JsonNode> data) {
-        super(data);
-    }
+    private final Names names;
+    private final String abbreviation;
+    private final String weblink;
+    private final String discord;
+    private final Map<String, String> moderators;
+    private final Instant created;
 
     public Series(JSONObject data) {
         super(data);
+
+        names = new Names(data.getJSONObject("names"));
+        abbreviation = data.getString("abbreviation");
+        weblink = data.getString("weblink");
+        discord = data.optString("discord", null);
+        Map<String, String> tempModerators = new HashMap<>();
+        for(String key : data.getJSONObject("moderators").keySet()) {
+            tempModerators.put(key, data.getJSONObject("moderators").getString(key));
+        }
+        moderators = Collections.unmodifiableMap(tempModerators);
+        if(!data.isNull("created")) {
+            created = Instant.parse(data.getString("created"));
+        } else {
+            created = null;
+        }
     }
 
     /**
@@ -41,23 +50,6 @@ public class Series extends IdentifiableResource {
      */
     public SeriesGamesRequest getGames() {
         return new SeriesGamesRequest(this);
-    }
-
-    @Override
-    protected void parseFromJson(JSONObject data) {
-        super.parseFromJson(data);
-
-        names = new Names(data.getJSONObject("names"));
-        abbreviation = data.getString("abbreviation");
-        weblink = data.getString("weblink");
-        discord = data.optString("discord", null);
-        moderators = new HashMap<>();
-        for(String key : data.getJSONObject("moderators").keySet()) {
-            moderators.put(key, data.getJSONObject("moderators").getString(key));
-        }
-        moderators = Collections.unmodifiableMap(moderators);
-        if(!data.isNull("created"))
-            created = Instant.parse(data.getString("created"));
     }
 
     /**

--- a/src/main/java/com/github/treescrub/spedran/data/category/Category.java
+++ b/src/main/java/com/github/treescrub/spedran/data/category/Category.java
@@ -3,8 +3,6 @@ package com.github.treescrub.spedran.data.category;
 import com.github.treescrub.spedran.api.request.category.CategoryRecordsRequest;
 import com.github.treescrub.spedran.api.request.category.CategoryVariablesRequest;
 import com.github.treescrub.spedran.data.IdentifiableNamedResource;
-import kong.unirest.HttpResponse;
-import kong.unirest.JsonNode;
 import kong.unirest.json.JSONObject;
 
 /**
@@ -13,18 +11,20 @@ import kong.unirest.json.JSONObject;
  * Common category names are {@code Any%}, {@code 100%}, and so on.
  */
 public class Category extends IdentifiableNamedResource {
-    private String weblink;
-    private boolean isPerLevel;
-    private String rules;
-    private CategoryPlayers players;
-    private boolean miscellaneous;
-
-    public Category(HttpResponse<JsonNode> data) {
-        super(data);
-    }
+    private final String weblink;
+    private final boolean isPerLevel;
+    private final String rules;
+    private final CategoryPlayers players;
+    private final boolean miscellaneous;
 
     public Category(JSONObject data) {
         super(data);
+
+        weblink = data.getString("weblink");
+        isPerLevel = data.getString("type").equals("per-level");
+        rules = data.getString("rules");
+        players = new CategoryPlayers(data.getJSONObject("players"));
+        miscellaneous = data.getBoolean("miscellaneous");
     }
 
     /**
@@ -43,17 +43,6 @@ public class Category extends IdentifiableNamedResource {
      */
     public CategoryVariablesRequest getVariables() {
         return new CategoryVariablesRequest(this);
-    }
-
-    @Override
-    protected void parseFromJson(JSONObject data) {
-        super.parseFromJson(data);
-
-        weblink = data.getString("weblink");
-        isPerLevel = data.getString("type").equals("per-level");
-        rules = data.getString("rules");
-        players = new CategoryPlayers(data.getJSONObject("players"));
-        miscellaneous = data.getBoolean("miscellaneous");
     }
 
     /**

--- a/src/main/java/com/github/treescrub/spedran/data/category/CategoryPlayers.java
+++ b/src/main/java/com/github/treescrub/spedran/data/category/CategoryPlayers.java
@@ -6,14 +6,10 @@ import kong.unirest.json.JSONObject;
  * Contains the rules for how many players can participate in the category.
  */
 public class CategoryPlayers {
-    private boolean isExact;
-    private int players;
+    private final boolean isExact;
+    private final int players;
 
     public CategoryPlayers(JSONObject data) {
-        parseFromJson(data);
-    }
-
-    private void parseFromJson(JSONObject data) {
         isExact = data.getString("type").equals("exactly");
         players = data.getInt("value");
     }

--- a/src/main/java/com/github/treescrub/spedran/data/game/Game.java
+++ b/src/main/java/com/github/treescrub/spedran/data/game/Game.java
@@ -1,12 +1,10 @@
 package com.github.treescrub.spedran.data.game;
 
-import kong.unirest.HttpResponse;
-import kong.unirest.JsonNode;
-import kong.unirest.json.JSONObject;
 import com.github.treescrub.spedran.api.request.game.*;
-import com.github.treescrub.spedran.data.ParseUtils;
 import com.github.treescrub.spedran.data.IdentifiableResource;
 import com.github.treescrub.spedran.data.Names;
+import com.github.treescrub.spedran.data.ParseUtils;
+import kong.unirest.json.JSONObject;
 
 import java.time.Instant;
 import java.time.LocalDate;
@@ -16,30 +14,48 @@ import java.util.*;
  * A game which has a leaderboard on SRC.
  */
 public class Game extends IdentifiableResource {
-    private Names names;
-    private Integer boostReceived;
-    private Integer boostDistinctDonors;
-    private String abbreviation;
-    private String weblink;
-    private String discord;
-    private LocalDate releaseDate;
-    private GameRuleset ruleset;
-    private List<String> gametypes;
-    private List<String> platforms;
-    private List<String> regions;
-    private List<String> genres;
-    private List<String> engines;
-    private List<String> developers;
-    private List<String> publishers;
-    private Map<String, String> moderators;
-    private Instant created;
-
-    public Game(HttpResponse<JsonNode> data) {
-        super(data);
-    }
+    private final Names names;
+    private final Integer boostReceived;
+    private final Integer boostDistinctDonors;
+    private final String abbreviation;
+    private final String weblink;
+    private final String discord;
+    private final LocalDate releaseDate;
+    private final GameRuleset ruleset;
+    private final List<String> gametypes;
+    private final List<String> platforms;
+    private final List<String> regions;
+    private final List<String> genres;
+    private final List<String> engines;
+    private final List<String> developers;
+    private final List<String> publishers;
+    private final Map<String, String> moderators;
+    private final Instant created;
 
     public Game(JSONObject data) {
         super(data);
+
+        names = new Names(data.getJSONObject("names"));
+        boostReceived = data.getInt("boostReceived");
+        boostDistinctDonors = data.getInt("boostDistinctDonors");
+        abbreviation = data.getString("abbreviation");
+        weblink = data.getString("weblink");
+        discord = data.getString("discord").isEmpty() ? null : data.getString("discord");
+        releaseDate = LocalDate.parse(data.getString("release-date"));
+        ruleset = new GameRuleset(data.getJSONObject("ruleset"));
+        gametypes = ParseUtils.getStringList(data.getJSONArray("gametypes"));
+        platforms = ParseUtils.getStringList(data.getJSONArray("platforms"));
+        regions = ParseUtils.getStringList(data.getJSONArray("regions"));
+        genres = ParseUtils.getStringList(data.getJSONArray("genres"));
+        engines = ParseUtils.getStringList(data.getJSONArray("engines"));
+        developers = ParseUtils.getStringList(data.getJSONArray("developers"));
+        publishers = ParseUtils.getStringList(data.getJSONArray("publishers"));
+        Map<String, String> tempModerators = new HashMap<>();
+        for(String key : data.getJSONObject("moderators").keySet()) {
+            tempModerators.put(key, data.getJSONObject("moderators").getString(key));
+        }
+        moderators = Collections.unmodifiableMap(tempModerators);
+        created = !data.isNull("created") ? Instant.parse(data.getString("created")) : null;
     }
 
     /**
@@ -85,34 +101,6 @@ public class Game extends IdentifiableResource {
      */
     public GameVariablesRequest getVariables() {
         return new GameVariablesRequest(this);
-    }
-
-    @Override
-    protected void parseFromJson(JSONObject data) {
-        super.parseFromJson(data);
-
-        names = new Names(data.getJSONObject("names"));
-        boostReceived = data.getInt("boostReceived");
-        boostDistinctDonors = data.getInt("boostDistinctDonors");
-        abbreviation = data.getString("abbreviation");
-        weblink = data.getString("weblink");
-        discord = data.getString("discord").isEmpty() ? null : data.getString("discord");
-        releaseDate = LocalDate.parse(data.getString("release-date"));
-        ruleset = new GameRuleset(data.getJSONObject("ruleset"));
-        gametypes = ParseUtils.getStringList(data.getJSONArray("gametypes"));
-        platforms = ParseUtils.getStringList(data.getJSONArray("platforms"));
-        regions = ParseUtils.getStringList(data.getJSONArray("regions"));
-        genres = ParseUtils.getStringList(data.getJSONArray("genres"));
-        engines = ParseUtils.getStringList(data.getJSONArray("engines"));
-        developers = ParseUtils.getStringList(data.getJSONArray("developers"));
-        publishers = ParseUtils.getStringList(data.getJSONArray("publishers"));
-        moderators = new HashMap<>();
-        for(String key : data.getJSONObject("moderators").keySet()) {
-            moderators.put(key, data.getJSONObject("moderators").getString(key));
-        }
-        moderators = Collections.unmodifiableMap(moderators);
-        if(!data.isNull("created"))
-            created = Instant.parse(data.getString("created"));
     }
 
     /**
@@ -200,7 +188,7 @@ public class Game extends IdentifiableResource {
      * @see com.github.treescrub.spedran.api.Spedran#getGametype(String)
      */
     public List<String> getGametypes() {
-        return Collections.unmodifiableList(gametypes);
+        return gametypes;
     }
 
     /**
@@ -212,7 +200,7 @@ public class Game extends IdentifiableResource {
      * @see com.github.treescrub.spedran.api.Spedran#getPlatform(String)
      */
     public List<String> getPlatforms() {
-        return Collections.unmodifiableList(platforms);
+        return platforms;
     }
 
     /**
@@ -224,7 +212,7 @@ public class Game extends IdentifiableResource {
      * @see com.github.treescrub.spedran.api.Spedran#getRegion(String)
      */
     public List<String> getRegions() {
-        return Collections.unmodifiableList(regions);
+        return regions;
     }
 
     /**
@@ -236,7 +224,7 @@ public class Game extends IdentifiableResource {
      * @see com.github.treescrub.spedran.api.Spedran#getGenre(String)
      */
     public List<String> getGenres() {
-        return Collections.unmodifiableList(genres);
+        return genres;
     }
 
     /**
@@ -248,7 +236,7 @@ public class Game extends IdentifiableResource {
      * @see com.github.treescrub.spedran.api.Spedran#getEngine(String)
      */
     public List<String> getEngines() {
-        return Collections.unmodifiableList(engines);
+        return engines;
     }
 
     /**
@@ -260,7 +248,7 @@ public class Game extends IdentifiableResource {
      * @see com.github.treescrub.spedran.api.Spedran#getDeveloper(String)
      */
     public List<String> getDevelopers() {
-        return Collections.unmodifiableList(developers);
+        return developers;
     }
 
     /**
@@ -272,7 +260,7 @@ public class Game extends IdentifiableResource {
      * @see com.github.treescrub.spedran.api.Spedran#getPublisher(String)
      */
     public List<String> getPublishers() {
-        return Collections.unmodifiableList(publishers);
+        return publishers;
     }
 
     /**
@@ -284,7 +272,7 @@ public class Game extends IdentifiableResource {
      * @see com.github.treescrub.spedran.api.Spedran#getUser(String)
      */
     public Map<String, String> getModerators() {
-        return Collections.unmodifiableMap(moderators);
+        return moderators;
     }
 
     /**

--- a/src/main/java/com/github/treescrub/spedran/data/game/GameRuleset.java
+++ b/src/main/java/com/github/treescrub/spedran/data/game/GameRuleset.java
@@ -12,27 +12,23 @@ import java.util.List;
  * These are not rules in the sense of moderating the leaderboard, but rather as restrictions when submitting a run.
  */
 public class GameRuleset {
-    private boolean showMilliseconds;
-    private boolean requireVerification;
-    private boolean requireVideo;
-    private List<TimingType> runTimes;
-    private TimingType defaultTime;
-    private boolean emulatorsAllowed;
+    private final boolean showMilliseconds;
+    private final boolean requireVerification;
+    private final boolean requireVideo;
+    private final List<TimingType> runTimes;
+    private final TimingType defaultTime;
+    private final boolean emulatorsAllowed;
 
     public GameRuleset(JSONObject data) {
-        runTimes = new ArrayList<>();
-        parseFromJson(data);
-    }
-
-    private void parseFromJson(JSONObject data) {
         showMilliseconds = data.getBoolean("show-milliseconds");
         requireVerification = data.getBoolean("require-verification");
         requireVideo = data.getBoolean("require-video");
+        List<TimingType> tempRunTimes = new ArrayList<>();
         for(Object element : data.getJSONArray("run-times")) {
             String timingType = (String) element;
-            runTimes.add(TimingType.valueOf(timingType.toUpperCase()));
+            tempRunTimes.add(TimingType.valueOf(timingType.toUpperCase()));
         }
-        runTimes = Collections.unmodifiableList(runTimes);
+        runTimes = Collections.unmodifiableList(tempRunTimes);
         defaultTime = TimingType.valueOf(data.getString("default-time").toUpperCase());
         emulatorsAllowed = data.getBoolean("emulators-allowed");
     }
@@ -79,7 +75,7 @@ public class GameRuleset {
      * @return a {@code List} of {@code TimingType}s
      */
     public List<TimingType> getRunTimes() {
-        return Collections.unmodifiableList(runTimes);
+        return runTimes;
     }
 
     /**

--- a/src/main/java/com/github/treescrub/spedran/data/leaderboard/Leaderboard.java
+++ b/src/main/java/com/github/treescrub/spedran/data/leaderboard/Leaderboard.java
@@ -1,10 +1,8 @@
 package com.github.treescrub.spedran.data.leaderboard;
 
-import kong.unirest.HttpResponse;
-import kong.unirest.JsonNode;
-import kong.unirest.json.JSONObject;
 import com.github.treescrub.spedran.data.Resource;
 import com.github.treescrub.spedran.data.run.TimingType;
+import kong.unirest.json.JSONObject;
 
 import java.util.*;
 
@@ -13,28 +11,21 @@ import java.util.*;
  * Does not contain obsoleted runs.
  */
 public class Leaderboard extends Resource {
-    private String weblink;
-    private String game;
-    private String category;
-    private String level;
-    private String platform;
-    private String region;
-    private Boolean emulators;
-    private boolean videoOnly;
-    private TimingType timing;
-    private Map<String, String> values;
-    private List<LeaderboardRun> runs;
-
-    public Leaderboard(HttpResponse<JsonNode> data) {
-        super(data);
-    }
+    private final String weblink;
+    private final String game;
+    private final String category;
+    private final String level;
+    private final String platform;
+    private final String region;
+    private final Boolean emulators;
+    private final boolean videoOnly;
+    private final TimingType timing;
+    private final Map<String, String> values;
+    private final List<LeaderboardRun> runs;
 
     public Leaderboard(JSONObject data) {
         super(data);
-    }
 
-    @Override
-    protected void parseFromJson(JSONObject data) {
         weblink = data.getString("weblink");
         game = data.getString("game");
         category = data.getString("category");
@@ -44,17 +35,17 @@ public class Leaderboard extends Resource {
         emulators = data.isNull("emulators") ? null : data.getBoolean("emulators");
         videoOnly = data.getBoolean("video-only");
         timing = TimingType.valueOf(data.getString("timing").toUpperCase());
-        values = new HashMap<>();
+        Map<String, String> tempValues = new HashMap<>();
         for(String key : data.getJSONObject("values").keySet()) {
-            values.put(key, data.getString(key));
+            tempValues.put(key, data.getString(key));
         }
-        values = Collections.unmodifiableMap(values);
-        runs = new ArrayList<>();
+        values = Collections.unmodifiableMap(tempValues);
+        List<LeaderboardRun> tempRuns = new ArrayList<>();
         for(Object object : data.getJSONArray("runs")) {
             JSONObject runData = (JSONObject) object;
-            runs.add(new LeaderboardRun(runData));
+            tempRuns.add(new LeaderboardRun(runData));
         }
-        runs = Collections.unmodifiableList(runs);
+        runs = Collections.unmodifiableList(tempRuns);
     }
 
     /**

--- a/src/main/java/com/github/treescrub/spedran/data/leaderboard/LeaderboardRun.java
+++ b/src/main/java/com/github/treescrub/spedran/data/leaderboard/LeaderboardRun.java
@@ -8,15 +8,12 @@ import com.github.treescrub.spedran.data.run.Run;
  * A run on a leaderboard. Has a place on the leaderboard and the associated run.
  */
 public class LeaderboardRun extends Resource {
-    private int place;
-    private Run run;
+    private final int place;
+    private final Run run;
 
     public LeaderboardRun(JSONObject data) {
         super(data);
-    }
 
-    @Override
-    protected void parseFromJson(JSONObject data) {
         place = data.getInt("place");
         run = new Run(data.getJSONObject("run"));
     }

--- a/src/main/java/com/github/treescrub/spedran/data/run/Run.java
+++ b/src/main/java/com/github/treescrub/spedran/data/run/Run.java
@@ -1,13 +1,11 @@
 package com.github.treescrub.spedran.data.run;
 
-import kong.unirest.HttpResponse;
-import kong.unirest.JsonNode;
-import kong.unirest.json.JSONObject;
 import com.github.treescrub.spedran.api.request.run.DeleteRunRequest;
 import com.github.treescrub.spedran.api.request.run.RunPlayersRequest;
 import com.github.treescrub.spedran.api.request.run.RunStatusRequest;
 import com.github.treescrub.spedran.data.IdentifiableResource;
 import com.github.treescrub.spedran.data.Link;
+import kong.unirest.json.JSONObject;
 
 import java.time.Instant;
 import java.time.LocalDate;
@@ -17,27 +15,46 @@ import java.util.*;
  * A speedrun on SRC.
  */
 public class Run extends IdentifiableResource {
-    private String weblink;
-    private String game;
-    private String level;
-    private String category;
-    private RunVideos videos;
-    private String comment;
-    private RunStatus status;
-    private List<RunPlayer> players;
-    private LocalDate date;
-    private Instant submitted;
-    private RunTimes times;
-    private RunSystem system;
-    private Link splits;
-    private Map<String, String> values;
-
-    public Run(HttpResponse<JsonNode> data) {
-        super(data);
-    }
+    private final String weblink;
+    private final String game;
+    private final String level;
+    private final String category;
+    private final RunVideos videos;
+    private final String comment;
+    private final RunStatus status;
+    private final List<RunPlayer> players;
+    private final LocalDate date;
+    private final Instant submitted;
+    private final RunTimes times;
+    private final RunSystem system;
+    private final Link splits;
+    private final Map<String, String> values;
 
     public Run(JSONObject data) {
         super(data);
+
+        weblink = data.getString("weblink");
+        game = data.getString("game");
+        level = data.optString("level", null);
+        category = data.getString("category");
+        videos = data.isNull("videos") ? null : new RunVideos(data.getJSONObject("videos"));
+        comment = data.optString("comment", null);
+        status = new RunStatus(data.getJSONObject("status"));
+        List<RunPlayer> tempPlayers = new ArrayList<>();
+        for(int i = 0; i < data.getJSONArray("players").length(); i++) {
+            tempPlayers.add(new RunPlayer(data.getJSONArray("players").getJSONObject(i)));
+        }
+        players = Collections.unmodifiableList(tempPlayers);
+        date = data.isNull("date") ? null : LocalDate.parse(data.getString("date"));
+        submitted = data.isNull("submitted") ? null : Instant.parse(data.getString("submitted"));
+        times = new RunTimes(data.getJSONObject("times"));
+        system = new RunSystem(data.getJSONObject("system"));
+        splits = data.isNull("splits") ? null : new Link(data.getJSONObject("splits"));
+        Map<String, String> tempValues = new HashMap<>();
+        for(String key : data.getJSONObject("values").keySet()) {
+            tempValues.put(key, data.getJSONObject("values").getString(key));
+        }
+        values = Collections.unmodifiableMap(tempValues);
     }
 
     /**
@@ -68,34 +85,6 @@ public class Run extends IdentifiableResource {
      */
     public RunStatusRequest setStatus() {
         return new RunStatusRequest(this);
-    }
-
-    @Override
-    protected void parseFromJson(JSONObject data) {
-        super.parseFromJson(data);
-
-        weblink = data.getString("weblink");
-        game = data.getString("game");
-        level = data.optString("level", null);
-        category = data.getString("category");
-        videos = data.isNull("videos") ? null : new RunVideos(data.getJSONObject("videos"));
-        comment = data.optString("comment", null);
-        status = new RunStatus(data.getJSONObject("status"));
-        players = new ArrayList<>();
-        for(int i = 0; i < data.getJSONArray("players").length(); i++) {
-            players.add(new RunPlayer(data.getJSONArray("players").getJSONObject(i)));
-        }
-        players = Collections.unmodifiableList(players);
-        date = data.isNull("date") ? null : LocalDate.parse(data.getString("date"));
-        submitted = data.isNull("submitted") ? null : Instant.parse(data.getString("submitted"));
-        times = new RunTimes(data.getJSONObject("times"));
-        system = new RunSystem(data.getJSONObject("system"));
-        splits = data.isNull("splits") ? null : new Link(data.getJSONObject("splits"));
-        values = new HashMap<>();
-        for(String key : data.getJSONObject("values").keySet()) {
-            values.put(key, data.getJSONObject("values").getString(key));
-        }
-        values = Collections.unmodifiableMap(values);
     }
 
     /**

--- a/src/main/java/com/github/treescrub/spedran/data/run/RunPlayer.java
+++ b/src/main/java/com/github/treescrub/spedran/data/run/RunPlayer.java
@@ -8,20 +8,16 @@ import com.github.treescrub.spedran.data.Link;
  * Only makes sense in the context of a run.
  */
 public class RunPlayer extends Link {
-    private String id;
-    private boolean isGuest;
+    private final String id;
+    private final boolean isGuest;
 
     public RunPlayer(JSONObject data) {
         super(data);
-        parseFromJson(data);
-    }
 
-    private void parseFromJson(JSONObject data) {
-        if (!data.isNull("id")) {
+        if(!data.isNull("id")) {
             id = data.getString("id");
             isGuest = false;
-        }
-        if (!data.isNull("name")) {
+        } else {
             id = data.getString("name");
             isGuest = true;
         }

--- a/src/main/java/com/github/treescrub/spedran/data/run/RunStatus.java
+++ b/src/main/java/com/github/treescrub/spedran/data/run/RunStatus.java
@@ -9,20 +9,18 @@ import java.util.Optional;
  * The verification status of a {@link Run} on SRC.
  */
 public class RunStatus {
-    private SubmissionStatus submissionStatus;
-    private String examiner;
-    private Instant verifyDate;
-    private String reason;
+    private final SubmissionStatus submissionStatus;
+    private final String examiner;
+    private final Instant verifyDate;
+    private final String reason;
 
     public RunStatus(JSONObject data) {
-        parseFromJson(data);
-    }
-
-    private void parseFromJson(JSONObject data) {
         submissionStatus = SubmissionStatus.valueOf(data.getString("status").toUpperCase());
         examiner = data.optString("examiner", null);
         if(!data.isNull("verify-date")) {
             verifyDate = Instant.parse(data.getString("verify-date"));
+        } else {
+            verifyDate = null;
         }
         reason = data.optString("reason", null);
     }

--- a/src/main/java/com/github/treescrub/spedran/data/run/RunSystem.java
+++ b/src/main/java/com/github/treescrub/spedran/data/run/RunSystem.java
@@ -11,15 +11,11 @@ import java.util.Optional;
  * @see com.github.treescrub.spedran.data.Region
  */
 public class RunSystem {
-    private String platform;
-    private boolean emulated;
-    private String region;
+    private final String platform;
+    private final boolean emulated;
+    private final String region;
 
     public RunSystem(JSONObject data) {
-        parseFromJson(data);
-    }
-
-    private void parseFromJson(JSONObject data) {
         platform = data.optString("platform", null);
         emulated = data.getBoolean("emulated");
         region = data.optString("region", null);

--- a/src/main/java/com/github/treescrub/spedran/data/run/RunTimes.java
+++ b/src/main/java/com/github/treescrub/spedran/data/run/RunTimes.java
@@ -12,23 +12,16 @@ import java.util.Optional;
  * @see Run#getRunTimes()
  */
 public class RunTimes {
-    private Duration primaryTime;
-    private Duration realTime;
-    private Duration realNoLoadsTime;
-    private Duration ingameTime;
+    private final Duration primaryTime;
+    private final Duration realTime;
+    private final Duration realNoLoadsTime;
+    private final Duration ingameTime;
 
     public RunTimes(JSONObject data) {
-        parseFromJson(data);
-    }
-
-    private void parseFromJson(JSONObject data) {
         primaryTime = Duration.parse(data.getString("primary"));
-        if (!data.isNull("realtime"))
-            realTime = Duration.parse(data.getString("realtime"));
-        if (!data.isNull("realtime_noloads"))
-            realNoLoadsTime = Duration.parse(data.getString("realtime_noloads"));
-        if (!data.isNull("ingame"))
-            ingameTime = Duration.parse(data.getString("ingame"));
+        realTime = !data.isNull("realtime") ? Duration.parse(data.getString("realtime")) : null;
+        realNoLoadsTime = !data.isNull("realtime_noloads") ? Duration.parse(data.getString("realtime_noloads")) : null;
+        ingameTime = !data.isNull("ingame") ? Duration.parse(data.getString("ingame")) : null;
     }
 
     /**

--- a/src/main/java/com/github/treescrub/spedran/data/run/RunVideos.java
+++ b/src/main/java/com/github/treescrub/spedran/data/run/RunVideos.java
@@ -16,22 +16,18 @@ import java.util.Optional;
  * If the main video section contains more than just a video link, {@link RunVideos#text} is set.
  */
 public class RunVideos {
-    private String text;
-    private List<Link> links;
+    private final String text;
+    private final List<Link> links;
 
     public RunVideos(JSONObject data) {
-        parseFromJson(data);
-    }
-
-    private void parseFromJson(JSONObject data) {
         text = data.isNull("text") ? null : data.getString("text");
-        links = new ArrayList<>();
+        List<Link> tempLinks = new ArrayList<>();
         if(data.has("links")) {
             for (int i = 0; i < data.getJSONArray("links").length(); i++) {
-                links.add(new Link(data.getJSONArray("links").getJSONObject(i)));
+                tempLinks.add(new Link(data.getJSONArray("links").getJSONObject(i)));
             }
         }
-        links = Collections.unmodifiableList(links);
+        links = Collections.unmodifiableList(tempLinks);
     }
 
     /**

--- a/src/main/java/com/github/treescrub/spedran/data/user/LocationInfo.java
+++ b/src/main/java/com/github/treescrub/spedran/data/user/LocationInfo.java
@@ -9,14 +9,10 @@ import java.util.Objects;
  * Contains a location code and {@link Names} for a location in the world.
  */
 public class LocationInfo {
-    private String code;
-    private Names names;
+    private final String code;
+    private final Names names;
 
     public LocationInfo(JSONObject data) {
-        parseFromJson(data);
-    }
-
-    private void parseFromJson(JSONObject data) {
         code = data.getString("code");
         names = new Names(data.getJSONObject("names"));
     }

--- a/src/main/java/com/github/treescrub/spedran/data/user/NameColor.java
+++ b/src/main/java/com/github/treescrub/spedran/data/user/NameColor.java
@@ -8,14 +8,10 @@ import kong.unirest.json.JSONObject;
  * Has light and dark hex color codes for light and dark backgrounds.
  */
 public class NameColor {
-    private String light;
-    private String dark;
+    private final String light;
+    private final String dark;
 
     public NameColor(JSONObject data) {
-        parseFromJson(data);
-    }
-
-    private void parseFromJson(JSONObject data) {
         light = data.getString("light");
         dark = data.getString("dark");
     }

--- a/src/main/java/com/github/treescrub/spedran/data/user/NameStyle.java
+++ b/src/main/java/com/github/treescrub/spedran/data/user/NameStyle.java
@@ -15,20 +15,19 @@ public class NameStyle {
         GRADIENT,
     }
 
-    private Style style;
-    private NameColor color;
-    private NameColor startColor;
-    private NameColor endColor;
+    private final Style style;
+    private final NameColor color;
+    private final NameColor startColor;
+    private final NameColor endColor;
 
     public NameStyle(JSONObject data) {
-        parseFromJson(data);
-    }
-
-    private void parseFromJson(JSONObject data) {
         style = Style.valueOf(data.getString("style").toUpperCase());
         if (style == Style.SOLID) {
             color = new NameColor(data.getJSONObject("color"));
+            startColor = null;
+            endColor = null;
         } else {
+            color = null;
             startColor = new NameColor(data.getJSONObject("color-from"));
             endColor = new NameColor(data.getJSONObject("color-to"));
         }

--- a/src/main/java/com/github/treescrub/spedran/data/user/User.java
+++ b/src/main/java/com/github/treescrub/spedran/data/user/User.java
@@ -4,8 +4,6 @@ import com.github.treescrub.spedran.api.request.user.UserPBsRequest;
 import com.github.treescrub.spedran.data.IdentifiableResource;
 import com.github.treescrub.spedran.data.Link;
 import com.github.treescrub.spedran.data.Names;
-import kong.unirest.HttpResponse;
-import kong.unirest.JsonNode;
 import kong.unirest.json.JSONObject;
 
 import java.time.Instant;
@@ -15,40 +13,22 @@ import java.util.Optional;
  * Represents a user on SRC.
  */
 public class User extends IdentifiableResource {
-    private Names names;
-    private boolean supporterAnimation;
-    private String pronouns;
-    private String weblink;
-    private NameStyle nameStyle;
-    private UserRole role;
-    private Instant signup;
-    private UserLocation location;
-    private Link twitch;
-    private Link hitbox;
-    private Link youtube;
-    private Link twitter;
-    private Link speedrunsLive;
-
-    public User(HttpResponse<JsonNode> data) {
-        this(data.getBody().getObject().getJSONObject("data"));
-    }
+    private final Names names;
+    private final boolean supporterAnimation;
+    private final String pronouns;
+    private final String weblink;
+    private final NameStyle nameStyle;
+    private final UserRole role;
+    private final Instant signup;
+    private final UserLocation location;
+    private final Link twitch;
+    private final Link hitbox;
+    private final Link youtube;
+    private final Link twitter;
+    private final Link speedrunsLive;
 
     public User(JSONObject data) {
         super(data);
-    }
-
-    /**
-     * Gets a new {@link UserPBsRequest} builder object to request this user's personal best runs.
-     *
-     * @return a {@code UserPBsRequest} builder
-     */
-    public UserPBsRequest getPersonalBests() {
-        return new UserPBsRequest(this);
-    }
-
-    @Override
-    protected void parseFromJson(JSONObject data) {
-        super.parseFromJson(data);
 
         names = new Names(data.getJSONObject("names"));
         supporterAnimation = data.getBoolean("supporterAnimation");
@@ -63,6 +43,15 @@ public class User extends IdentifiableResource {
         youtube = data.isNull("youtube") ? null : new Link(data.getJSONObject("youtube"));
         twitter = data.isNull("twitter") ? null : new Link(data.getJSONObject("twitter"));
         speedrunsLive = data.isNull("speedrunslive") ? null : new Link(data.getJSONObject("speedrunslive"));
+    }
+
+    /**
+     * Gets a new {@link UserPBsRequest} builder object to request this user's personal best runs.
+     *
+     * @return a {@code UserPBsRequest} builder
+     */
+    public UserPBsRequest getPersonalBests() {
+        return new UserPBsRequest(this);
     }
 
     /**

--- a/src/main/java/com/github/treescrub/spedran/data/user/UserLocation.java
+++ b/src/main/java/com/github/treescrub/spedran/data/user/UserLocation.java
@@ -10,14 +10,10 @@ import java.util.Optional;
  * Has country info and may have region info.
  */
 public class UserLocation {
-    private LocationInfo country;
-    private LocationInfo region;
+    private final LocationInfo country;
+    private final LocationInfo region;
 
     public UserLocation(JSONObject data) {
-        parseFromJson(data);
-    }
-
-    private void parseFromJson(JSONObject data) {
         country = new LocationInfo(data.getJSONObject("country"));
         region = data.isNull("region") ? null : new LocationInfo(data.getJSONObject("region"));
     }

--- a/src/main/java/com/github/treescrub/spedran/data/variables/Variable.java
+++ b/src/main/java/com/github/treescrub/spedran/data/variables/Variable.java
@@ -2,9 +2,6 @@ package com.github.treescrub.spedran.data.variables;
 
 import com.github.treescrub.spedran.data.IdentifiableNamedResource;
 import com.github.treescrub.spedran.data.user.User;
-
-import kong.unirest.HttpResponse;
-import kong.unirest.JsonNode;
 import kong.unirest.json.JSONObject;
 
 import java.util.Collections;
@@ -16,26 +13,17 @@ import java.util.Optional;
  * A moderator defined variable for which a value can be set on a {@link com.github.treescrub.spedran.data.run.Run}.
  */
 public class Variable extends IdentifiableNamedResource {
-    private String category;
-    private VariableScope scope;
-    private boolean mandatory;
-    private boolean userDefined;
-    private boolean obsoletes;
-    private Map<String, VariableValue> values;
-    private String defaultValue;
-    private boolean isSubcategory;
-
-    public Variable(HttpResponse<JsonNode> data) {
-        super(data);
-    }
+    private final String category;
+    private final VariableScope scope;
+    private final boolean mandatory;
+    private final boolean userDefined;
+    private final boolean obsoletes;
+    private final Map<String, VariableValue> values;
+    private final String defaultValue;
+    private final boolean isSubcategory;
 
     public Variable(JSONObject data) {
         super(data);
-    }
-
-    @Override
-    protected void parseFromJson(JSONObject data) {
-        super.parseFromJson(data);
 
         category = data.optString("category", null);
         scope = new VariableScope(data.getJSONObject("scope"));
@@ -43,13 +31,14 @@ public class Variable extends IdentifiableNamedResource {
         userDefined = data.getBoolean("user-defined");
         obsoletes = data.getBoolean("obsoletes");
         defaultValue = data.getJSONObject("values").optString("default", null);
-        values = new HashMap<>();
+        Map<String, VariableValue> tempValues = new HashMap<>();
         for(String valueId : data.getJSONObject("values").getJSONObject("values").keySet()) {
-            values.put(valueId, new VariableValue(data.getJSONObject("values").getJSONObject("values").getJSONObject(valueId)));
+            tempValues.put(valueId, new VariableValue(data.getJSONObject("values").getJSONObject("values").getJSONObject(valueId)));
         }
-        values = Collections.unmodifiableMap(values);
+        values = Collections.unmodifiableMap(tempValues);
         isSubcategory = data.getBoolean("is-subcategory");
     }
+
 
     /**
      * Gets the category ID that this variable applies to.

--- a/src/main/java/com/github/treescrub/spedran/data/variables/VariableScope.java
+++ b/src/main/java/com/github/treescrub/spedran/data/variables/VariableScope.java
@@ -27,8 +27,8 @@ public class VariableScope {
         SINGLE_LEVEL
     }
 
-    private ScopeType type;
-    private String level;
+    private final ScopeType type;
+    private final String level;
 
     public VariableScope(JSONObject data) {
         type = parseType(data.getString("type"));

--- a/src/main/java/com/github/treescrub/spedran/data/variables/VariableValue.java
+++ b/src/main/java/com/github/treescrub/spedran/data/variables/VariableValue.java
@@ -13,29 +13,25 @@ import java.util.Optional;
  * Contains info about the value label. Also has rules text and flags if the variable is a subcategory.
  */
 public class VariableValue {
-    private String label;
-    private String rules;
-    private Map<String, Boolean> flags;
+    private final String label;
+    private final String rules;
+    private final Map<String, Boolean> flags;
 
     public VariableValue(JSONObject data) {
-        parseFromJson(data);
-    }
-
-    private void parseFromJson(JSONObject data) {
         label = data.getString("label");
         rules = data.optString("rules", null);
-        flags = new HashMap<>();
+        Map<String, Boolean> tempFlags = new HashMap<>();
         if(data.has("flags")) {
             JSONObject flagsObject = data.getJSONObject("flags");
             for(String key : flagsObject.keySet()) {
                 if(flagsObject.isNull(key)) {
-                    flags.put(key, null);
+                    tempFlags.put(key, null);
                 } else {
-                    flags.put(key, flagsObject.getBoolean(key));
+                    tempFlags.put(key, flagsObject.getBoolean(key));
                 }
             }
         }
-        flags = Collections.unmodifiableMap(flags);
+        flags = Collections.unmodifiableMap(tempFlags);
     }
 
     /**


### PR DESCRIPTION
Move initialization of Resource inheritors to the constructor and make all fields final to reduce redundancy and guarantee immutability.