### PR TITLE
Fix Leaderboard getEmulators to use Optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.treescrub</groupId>
     <artifactId>spedran</artifactId>
-    <version>0.14.0</version>
+    <version>0.15.0</version>
     <packaging>jar</packaging>
 
     <name>Spedran</name>

--- a/src/main/java/com/github/treescrub/spedran/data/leaderboard/Leaderboard.java
+++ b/src/main/java/com/github/treescrub/spedran/data/leaderboard/Leaderboard.java
@@ -123,8 +123,8 @@ public class Leaderboard extends Resource {
      *
      * @return {@code false} if runs using an emulator were filtered out, otherwise {@code true}
      */
-    public Boolean getEmulators() {
-        return emulators;
+    public Optional<Boolean> getEmulators() {
+        return Optional.ofNullable(emulators);
     }
 
     /**


### PR DESCRIPTION
Changes `getEmulators` to use an Optional for null values.

Closes #19 