### PR TITLE
Implement authenticated request builders

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.treescrub</groupId>
     <artifactId>spedran</artifactId>
-    <version>0.15.0</version>
+    <version>0.16.0</version>
     <packaging>jar</packaging>
 
     <name>Spedran</name>

--- a/src/main/java/com/github/treescrub/spedran/api/Spedran.java
+++ b/src/main/java/com/github/treescrub/spedran/api/Spedran.java
@@ -191,13 +191,13 @@ public class Spedran {
     }
 
     /**
-     * Gets a {@link RunPlayersRequest} builder to change the {@link User}s on a {@link Run}.
+     * Gets a {@link RunPlayersRequest} builder to change the players in a {@link Run}.
      *
      * @param runId the ID of the run to set the players for
      *
      * @return a {@code RunPlayersRequest} builder
      */
-    public static RunPlayersRequest getRunPlayers(String runId) {
+    public static RunPlayersRequest setRunPlayers(String runId) {
         return new RunPlayersRequest(runId);
     }
 

--- a/src/main/java/com/github/treescrub/spedran/api/Spedran.java
+++ b/src/main/java/com/github/treescrub/spedran/api/Spedran.java
@@ -183,12 +183,11 @@ public class Spedran {
      * Gets a {@link DeleteRunRequest} builder to delete a {@link Run}.
      *
      * @param runId the ID of the run to delete
-     * @param apiKey the API key to use. must have sufficient permissions to delete the run
      *
      * @return a {@code DeleteRunRequest} builder
      */
-    public static DeleteRunRequest deleteRun(String runId, String apiKey) {
-        return new DeleteRunRequest(runId, apiKey);
+    public static DeleteRunRequest deleteRun(String runId) {
+        return new DeleteRunRequest(runId);
     }
 
     /**

--- a/src/main/java/com/github/treescrub/spedran/api/Spedran.java
+++ b/src/main/java/com/github/treescrub/spedran/api/Spedran.java
@@ -319,6 +319,16 @@ public class Spedran {
     }
 
     /**
+     * Gets the {@link User} that owns the current API key.
+     *
+     * @return a {@link CompletableFuture} of the current authenticated {@code User}
+     * @see Spedran#setApiKey(String)
+     */
+    public static CompletableFuture<User> getProfile() {
+        return new ProfileRequest().complete();
+    }
+
+    /**
      * Gets the {@link User} that corresponds to the provided {@code id} asynchronously.
      *
      * @param id the ID of the user to get

--- a/src/main/java/com/github/treescrub/spedran/api/Spedran.java
+++ b/src/main/java/com/github/treescrub/spedran/api/Spedran.java
@@ -202,6 +202,15 @@ public class Spedran {
     }
 
     /**
+     * Gets a {@link SubmitRunRequest} builder to submit a run to SRC.
+     *
+     * @return a {@code SubmitRunRequest} builder
+     */
+    public static SubmitRunRequest submitRun() {
+        return new SubmitRunRequest();
+    }
+
+    /**
      * Gets a {@link RunStatusRequest} builder to change the {@link Run}'s verification status.
      *
      * @param runId the ID of the run to set the status of

--- a/src/main/java/com/github/treescrub/spedran/api/Spedran.java
+++ b/src/main/java/com/github/treescrub/spedran/api/Spedran.java
@@ -1,26 +1,45 @@
 package com.github.treescrub.spedran.api;
 
-import com.github.treescrub.spedran.api.request.category.*;
-import com.github.treescrub.spedran.api.request.developer.*;
-import com.github.treescrub.spedran.api.request.engine.*;
+import com.github.treescrub.spedran.api.request.NotificationsRequest;
+import com.github.treescrub.spedran.api.request.category.CategoryRecordsRequest;
+import com.github.treescrub.spedran.api.request.category.CategoryRequest;
+import com.github.treescrub.spedran.api.request.category.CategoryVariablesRequest;
+import com.github.treescrub.spedran.api.request.developer.DeveloperRequest;
+import com.github.treescrub.spedran.api.request.developer.DevelopersRequest;
+import com.github.treescrub.spedran.api.request.engine.EngineRequest;
+import com.github.treescrub.spedran.api.request.engine.EnginesRequest;
 import com.github.treescrub.spedran.api.request.game.*;
-import com.github.treescrub.spedran.api.request.gametype.*;
-import com.github.treescrub.spedran.api.request.genre.*;
+import com.github.treescrub.spedran.api.request.gametype.GametypeRequest;
+import com.github.treescrub.spedran.api.request.gametype.GametypesRequest;
+import com.github.treescrub.spedran.api.request.genre.GenreRequest;
+import com.github.treescrub.spedran.api.request.genre.GenresRequest;
 import com.github.treescrub.spedran.api.request.guest.GuestRequest;
 import com.github.treescrub.spedran.api.request.leaderboard.LeaderboardRequest;
-import com.github.treescrub.spedran.api.request.level.*;
-import com.github.treescrub.spedran.api.request.platform.*;
-import com.github.treescrub.spedran.api.request.publisher.*;
-import com.github.treescrub.spedran.api.request.region.*;
+import com.github.treescrub.spedran.api.request.level.LevelCategoriesRequest;
+import com.github.treescrub.spedran.api.request.level.LevelRecordsRequest;
+import com.github.treescrub.spedran.api.request.level.LevelRequest;
+import com.github.treescrub.spedran.api.request.level.LevelVariablesRequest;
+import com.github.treescrub.spedran.api.request.platform.PlatformRequest;
+import com.github.treescrub.spedran.api.request.platform.PlatformsRequest;
+import com.github.treescrub.spedran.api.request.publisher.PublisherRequest;
+import com.github.treescrub.spedran.api.request.publisher.PublishersRequest;
+import com.github.treescrub.spedran.api.request.region.RegionRequest;
+import com.github.treescrub.spedran.api.request.region.RegionsRequest;
 import com.github.treescrub.spedran.api.request.run.*;
-import com.github.treescrub.spedran.api.request.series.*;
-import com.github.treescrub.spedran.api.request.user.*;
+import com.github.treescrub.spedran.api.request.series.AllSeriesRequest;
+import com.github.treescrub.spedran.api.request.series.SeriesGamesRequest;
+import com.github.treescrub.spedran.api.request.series.SingleSeriesRequest;
+import com.github.treescrub.spedran.api.request.user.ProfileRequest;
+import com.github.treescrub.spedran.api.request.user.UserPBsRequest;
+import com.github.treescrub.spedran.api.request.user.UserRequest;
+import com.github.treescrub.spedran.api.request.user.UsersRequest;
 import com.github.treescrub.spedran.api.request.variable.VariableRequest;
 import com.github.treescrub.spedran.data.*;
 import com.github.treescrub.spedran.data.category.Category;
 import com.github.treescrub.spedran.data.game.Game;
 import com.github.treescrub.spedran.data.leaderboard.Leaderboard;
 import com.github.treescrub.spedran.data.leaderboard.LeaderboardRun;
+import com.github.treescrub.spedran.data.notification.Notification;
 import com.github.treescrub.spedran.data.run.Run;
 import com.github.treescrub.spedran.data.user.User;
 import com.github.treescrub.spedran.data.variables.Variable;
@@ -28,6 +47,7 @@ import com.github.treescrub.spedran.requests.Requests;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 @SuppressWarnings("unused")
@@ -326,6 +346,16 @@ public class Spedran {
      */
     public static CompletableFuture<User> getProfile() {
         return new ProfileRequest().complete();
+    }
+
+    /**
+     * Gets all of the {@link Notification}s for the currently authenticated user.
+     *
+     * @return a {@link CompletableFuture} with a {@code List} of notifications
+     * @see Spedran#setApiKey(String)
+     */
+    public static CompletableFuture<List<Notification>> getNotifications() {
+        return new NotificationsRequest().complete();
     }
 
     /**

--- a/src/main/java/com/github/treescrub/spedran/api/request/InvalidBuilderStateException.java
+++ b/src/main/java/com/github/treescrub/spedran/api/request/InvalidBuilderStateException.java
@@ -1,0 +1,7 @@
+package com.github.treescrub.spedran.api.request;
+
+public class InvalidBuilderStateException extends Exception {
+    public InvalidBuilderStateException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/github/treescrub/spedran/api/request/ModifyResourceRequest.java
+++ b/src/main/java/com/github/treescrub/spedran/api/request/ModifyResourceRequest.java
@@ -1,0 +1,21 @@
+package com.github.treescrub.spedran.api.request;
+
+import kong.unirest.HttpMethod;
+import kong.unirest.json.JSONElement;
+
+import java.util.concurrent.CompletableFuture;
+
+public abstract class ModifyResourceRequest<T> extends SingleResourceRequest<T> {
+    protected ModifyResourceRequest(HttpMethod method, String url) {
+        super(method, url);
+    }
+
+    protected abstract JSONElement buildBody();
+
+    @Override
+    public CompletableFuture<T> complete() {
+        request.body(buildBody());
+
+        return super.complete();
+    }
+}

--- a/src/main/java/com/github/treescrub/spedran/api/request/ModifyResourceRequest.java
+++ b/src/main/java/com/github/treescrub/spedran/api/request/ModifyResourceRequest.java
@@ -15,12 +15,20 @@ public abstract class ModifyResourceRequest<T> extends SingleResourceRequest<T> 
         super(method, url, routeParameters);
     }
 
-    protected abstract JSONElement buildBody();
+    protected abstract JSONElement buildBody() throws InvalidBuilderStateException;
 
     @Override
     public CompletableFuture<T> complete() {
-        request.body(buildBody());
+        try {
+            JSONElement body = buildBody();
 
-        return super.complete();
+            if(body != null) {
+                request.body(body);
+            }
+
+            return super.complete();
+        } catch (InvalidBuilderStateException e) {
+            return CompletableFuture.failedFuture(e);
+        }
     }
 }

--- a/src/main/java/com/github/treescrub/spedran/api/request/ModifyResourceRequest.java
+++ b/src/main/java/com/github/treescrub/spedran/api/request/ModifyResourceRequest.java
@@ -3,11 +3,16 @@ package com.github.treescrub.spedran.api.request;
 import kong.unirest.HttpMethod;
 import kong.unirest.json.JSONElement;
 
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 public abstract class ModifyResourceRequest<T> extends SingleResourceRequest<T> {
     protected ModifyResourceRequest(HttpMethod method, String url) {
         super(method, url);
+    }
+
+    public ModifyResourceRequest(HttpMethod method, String url, Map<String, Object> routeParameters) {
+        super(method, url, routeParameters);
     }
 
     protected abstract JSONElement buildBody();

--- a/src/main/java/com/github/treescrub/spedran/api/request/NotificationsRequest.java
+++ b/src/main/java/com/github/treescrub/spedran/api/request/NotificationsRequest.java
@@ -1,0 +1,18 @@
+package com.github.treescrub.spedran.api.request;
+
+import com.github.treescrub.spedran.data.notification.Notification;
+import kong.unirest.HttpMethod;
+import kong.unirest.json.JSONObject;
+
+import java.util.function.Function;
+
+public class NotificationsRequest extends ResourceCollectionRequest<Notification> {
+    public NotificationsRequest() {
+        super(HttpMethod.GET, "notifications");
+    }
+
+    @Override
+    protected Function<JSONObject, Notification> getConstructor() {
+        return Notification::new;
+    }
+}

--- a/src/main/java/com/github/treescrub/spedran/api/request/ResourceRequest.java
+++ b/src/main/java/com/github/treescrub/spedran/api/request/ResourceRequest.java
@@ -2,6 +2,7 @@ package com.github.treescrub.spedran.api.request;
 
 import kong.unirest.HttpMethod;
 import kong.unirest.HttpRequest;
+import kong.unirest.HttpRequestWithBody;
 import kong.unirest.HttpResponse;
 import com.github.treescrub.spedran.requests.Requests;
 
@@ -10,7 +11,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 public abstract class ResourceRequest<T> {
-    protected HttpRequest<?> request;
+    protected HttpRequestWithBody request;
     protected CompletableFuture<T> result;
     private Map<String, Object> queryParameters;
     protected boolean completed = false;

--- a/src/main/java/com/github/treescrub/spedran/api/request/run/DeleteRunRequest.java
+++ b/src/main/java/com/github/treescrub/spedran/api/request/run/DeleteRunRequest.java
@@ -1,25 +1,29 @@
 package com.github.treescrub.spedran.api.request.run;
 
-import kong.unirest.HttpMethod;
-import kong.unirest.json.JSONObject;
-import com.github.treescrub.spedran.api.request.SingleResourceRequest;
+import com.github.treescrub.spedran.api.request.ModifyResourceRequest;
 import com.github.treescrub.spedran.data.run.Run;
+import kong.unirest.HttpMethod;
+import kong.unirest.json.JSONElement;
+import kong.unirest.json.JSONObject;
 
 import java.util.Map;
 
-public class DeleteRunRequest extends SingleResourceRequest<Run> {
-    public DeleteRunRequest(String id, String apiKey) {
+public class DeleteRunRequest extends ModifyResourceRequest<Run> {
+    public DeleteRunRequest(String id) {
         super(HttpMethod.DELETE, "runs/{id}", Map.of("id", id));
-
-        request.header("X-API-Key", apiKey);
     }
 
-    public DeleteRunRequest(Run run, String apiKey) {
-        this(run.getId(), apiKey);
+    public DeleteRunRequest(Run run) {
+        this(run.getId());
     }
 
     @Override
     protected Run parse(JSONObject data) {
         return new Run(data);
+    }
+
+    @Override
+    protected JSONElement buildBody() {
+        return null;
     }
 }

--- a/src/main/java/com/github/treescrub/spedran/api/request/run/RunPlayersRequest.java
+++ b/src/main/java/com/github/treescrub/spedran/api/request/run/RunPlayersRequest.java
@@ -1,25 +1,114 @@
 package com.github.treescrub.spedran.api.request.run;
 
-import kong.unirest.HttpMethod;
-import kong.unirest.json.JSONObject;
-import com.github.treescrub.spedran.api.request.SingleResourceRequest;
+import com.github.treescrub.spedran.api.request.InvalidBuilderStateException;
+import com.github.treescrub.spedran.api.request.ModifyResourceRequest;
+import com.github.treescrub.spedran.data.Guest;
 import com.github.treescrub.spedran.data.run.Run;
+import com.github.treescrub.spedran.data.user.User;
+import kong.unirest.HttpMethod;
+import kong.unirest.json.JSONArray;
+import kong.unirest.json.JSONElement;
+import kong.unirest.json.JSONObject;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
 
-public class RunPlayersRequest extends SingleResourceRequest<Run> {
+/**
+ * A builder to set the players that participated in a {@link Run}.
+ * <br>
+ * Players will maintain the order that they were added.
+ * <br>
+ * Duplicate users/guests will be ignored.
+ */
+public class RunPlayersRequest extends ModifyResourceRequest<Run> {
+    private final Map<String, String> runPlayers;
+
     public RunPlayersRequest(String id) {
         super(HttpMethod.PUT, "runs/{id}/players", Map.of("id", id));
+
+        runPlayers = new LinkedHashMap<>();
     }
 
     public RunPlayersRequest(Run run) {
         this(run.getId());
     }
 
-    // TODO: authentication, run players serialization
+    /**
+     * Adds a {@link User} to the players that will be set on the {@link Run}.
+     *
+     * @param user the user to add to the list of players
+     * @return this builder object
+     */
+    public RunPlayersRequest addUser(User user) {
+        return addUser(user.getId());
+    }
+
+    /**
+     * Adds a {@link User} to the players that will be set on the {@link Run}.
+     *
+     * @param userId the ID of the user to add to the list of players
+     * @return this builder object
+     */
+    public RunPlayersRequest addUser(String userId) {
+        runPlayers.put("user", userId);
+
+        return this;
+    }
+
+    /**
+     * Adds a {@link Guest} to the players that will be set on the {@link Run}.
+     *
+     * @param guest the guest to add to the list of players
+     * @return this builder object
+     */
+    public RunPlayersRequest addGuest(Guest guest) {
+        return addGuest(guest.getName());
+    }
+
+    /**
+     * Adds a {@link Guest} to the players that will be set on the {@link Run}.
+     *
+     * @param guestName the name of the guest to add to the list of players
+     * @return this builder object
+     */
+    public RunPlayersRequest addGuest(String guestName) {
+        runPlayers.put("guest", guestName);
+
+        return this;
+    }
 
     @Override
     protected Run parse(JSONObject data) {
         return new Run(data);
+    }
+
+    @Override
+    protected JSONElement buildBody() throws InvalidBuilderStateException {
+        if(runPlayers.isEmpty()) {
+            throw new InvalidBuilderStateException("At least one player must be set");
+        }
+        if(runPlayers.size() > 20) {
+            throw new InvalidBuilderStateException("Exceeded max number of players (20)");
+        }
+
+        JSONArray playersNode = new JSONArray();
+        for(Map.Entry<String, String> entry : runPlayers.entrySet()) {
+            JSONObject playerNode = new JSONObject();
+            playerNode.put("rel", entry.getKey());
+
+            String idKeyName;
+            if(entry.getKey().equals("user")) {
+                idKeyName = "id";
+            } else {
+                idKeyName = "name";
+            }
+
+            playerNode.put(idKeyName, entry.getValue());
+        }
+
+        JSONObject rootNode = new JSONObject();
+        rootNode.put("players", playersNode);
+
+        return rootNode;
     }
 }

--- a/src/main/java/com/github/treescrub/spedran/api/request/run/RunPlayersRequest.java
+++ b/src/main/java/com/github/treescrub/spedran/api/request/run/RunPlayersRequest.java
@@ -104,6 +104,7 @@ public class RunPlayersRequest extends ModifyResourceRequest<Run> {
             }
 
             playerNode.put(idKeyName, entry.getValue());
+            playersNode.put(playerNode);
         }
 
         JSONObject rootNode = new JSONObject();

--- a/src/main/java/com/github/treescrub/spedran/api/request/run/RunPlayersRequest.java
+++ b/src/main/java/com/github/treescrub/spedran/api/request/run/RunPlayersRequest.java
@@ -50,7 +50,7 @@ public class RunPlayersRequest extends ModifyResourceRequest<Run> {
      * @return this builder object
      */
     public RunPlayersRequest addUser(String userId) {
-        runPlayers.put("user", userId);
+        runPlayers.put(userId, "user");
 
         return this;
     }
@@ -72,7 +72,7 @@ public class RunPlayersRequest extends ModifyResourceRequest<Run> {
      * @return this builder object
      */
     public RunPlayersRequest addGuest(String guestName) {
-        runPlayers.put("guest", guestName);
+        runPlayers.put(guestName, "guest");
 
         return this;
     }
@@ -94,16 +94,20 @@ public class RunPlayersRequest extends ModifyResourceRequest<Run> {
         JSONArray playersNode = new JSONArray();
         for(Map.Entry<String, String> entry : runPlayers.entrySet()) {
             JSONObject playerNode = new JSONObject();
-            playerNode.put("rel", entry.getKey());
+
+            String id = entry.getKey();
+            String type = entry.getValue();
+
+            playerNode.put("rel", type);
 
             String idKeyName;
-            if(entry.getKey().equals("user")) {
+            if(type.equals("user")) {
                 idKeyName = "id";
             } else {
                 idKeyName = "name";
             }
 
-            playerNode.put(idKeyName, entry.getValue());
+            playerNode.put(idKeyName, id);
             playersNode.put(playerNode);
         }
 

--- a/src/main/java/com/github/treescrub/spedran/api/request/run/RunStatusRequest.java
+++ b/src/main/java/com/github/treescrub/spedran/api/request/run/RunStatusRequest.java
@@ -36,6 +36,7 @@ public class RunStatusRequest extends ModifyResourceRequest<Void> {
     /**
      * Sets the status of the {@link Run} to {@link SubmissionStatus#REJECTED} with the provided rejection reason.
      *
+     * @param reason a {@code String} with the reason for this run being rejected
      * @return this builder object
      */
     public RunStatusRequest reject(String reason) {

--- a/src/main/java/com/github/treescrub/spedran/api/request/run/RunStatusRequest.java
+++ b/src/main/java/com/github/treescrub/spedran/api/request/run/RunStatusRequest.java
@@ -1,13 +1,19 @@
 package com.github.treescrub.spedran.api.request.run;
 
-import kong.unirest.HttpMethod;
-import kong.unirest.json.JSONObject;
-import com.github.treescrub.spedran.api.request.SingleResourceRequest;
+import com.github.treescrub.spedran.api.request.InvalidBuilderStateException;
+import com.github.treescrub.spedran.api.request.ModifyResourceRequest;
 import com.github.treescrub.spedran.data.run.Run;
+import com.github.treescrub.spedran.data.run.SubmissionStatus;
+import kong.unirest.HttpMethod;
+import kong.unirest.json.JSONElement;
+import kong.unirest.json.JSONObject;
 
 import java.util.Map;
 
-public class RunStatusRequest extends SingleResourceRequest<Void> {
+public class RunStatusRequest extends ModifyResourceRequest<Void> {
+    private SubmissionStatus statusType;
+    private String rejectionReason;
+
     public RunStatusRequest(String id) {
         super(HttpMethod.PUT, "runs/{id}/status", Map.of("id", id));
     }
@@ -16,10 +22,50 @@ public class RunStatusRequest extends SingleResourceRequest<Void> {
         this(run.getId());
     }
 
-    // TODO: authentication, run status serialization
+    /**
+     * Sets the status of the {@link Run} to {@link SubmissionStatus#VERIFIED}.
+     *
+     * @return this builder object
+     */
+    public RunStatusRequest verify() {
+        statusType = SubmissionStatus.VERIFIED;
+
+        return this;
+    }
+
+    /**
+     * Sets the status of the {@link Run} to {@link SubmissionStatus#REJECTED} with the provided rejection reason.
+     *
+     * @return this builder object
+     */
+    public RunStatusRequest reject(String reason) {
+        statusType = SubmissionStatus.REJECTED;
+        rejectionReason = reason;
+
+        return this;
+    }
 
     @Override
     protected Void parse(JSONObject data) {
         return null;
+    }
+
+    @Override
+    protected JSONElement buildBody() throws InvalidBuilderStateException {
+        if(statusType == null) {
+            throw new InvalidBuilderStateException("The status type was not set");
+        }
+
+        JSONObject statusNode = new JSONObject();
+        statusNode.put("status", statusType.toAPIName());
+
+        if(statusType == SubmissionStatus.REJECTED) {
+            statusNode.put("reason", rejectionReason);
+        }
+
+        JSONObject rootNode = new JSONObject();
+        rootNode.put("status", statusNode);
+
+        return rootNode;
     }
 }

--- a/src/main/java/com/github/treescrub/spedran/api/request/run/SubmitRunRequest.java
+++ b/src/main/java/com/github/treescrub/spedran/api/request/run/SubmitRunRequest.java
@@ -1,19 +1,450 @@
 package com.github.treescrub.spedran.api.request.run;
 
-import kong.unirest.HttpMethod;
-import kong.unirest.json.JSONObject;
-import com.github.treescrub.spedran.api.request.SingleResourceRequest;
+import com.github.treescrub.spedran.api.request.InvalidBuilderStateException;
+import com.github.treescrub.spedran.api.request.ModifyResourceRequest;
+import com.github.treescrub.spedran.data.Guest;
+import com.github.treescrub.spedran.data.Level;
+import com.github.treescrub.spedran.data.Platform;
+import com.github.treescrub.spedran.data.Region;
+import com.github.treescrub.spedran.data.category.Category;
 import com.github.treescrub.spedran.data.run.Run;
+import com.github.treescrub.spedran.data.user.User;
+import com.github.treescrub.spedran.data.variables.Variable;
+import kong.unirest.HttpMethod;
+import kong.unirest.json.JSONArray;
+import kong.unirest.json.JSONElement;
+import kong.unirest.json.JSONObject;
 
-public class SubmitRunRequest extends SingleResourceRequest<Run> {
-    public SubmitRunRequest() {
-        super(HttpMethod.POST, "runs");
+import java.time.Duration;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class SubmitRunRequest extends ModifyResourceRequest<Run> {
+    private enum VariableType {
+        USER_DEFINED,
+        PREDEFINED,
     }
 
-    // TODO: authentication, run serialization
+    private static class RunVariable {
+        VariableType type;
+        String value;
+
+        public RunVariable(VariableType type, String value) {
+            this.type = type;
+            this.value = value;
+        }
+    }
+
+    private String categoryId;
+    private String levelId;
+    private LocalDate date;
+    private String regionId;
+    private String platformId;
+    private boolean verified;
+    private final Map<String, Duration> times;
+    private final Map<String, String> players;
+    private boolean isEmulated;
+    private String videoUrl;
+    private String comment;
+    private String splitsIO;
+    private final Map<String, RunVariable> variables;
+
+    public SubmitRunRequest() {
+        super(HttpMethod.POST, "runs");
+
+        verified = false;
+        times = new HashMap<>();
+        players = new LinkedHashMap<>();
+        isEmulated = false;
+        variables = new HashMap<>();
+    }
+
+    /**
+     * Sets the {@link Category} for the run.
+     *
+     * @param category the category that the run is in
+     * @return this builder object
+     */
+    public SubmitRunRequest category(Category category) {
+        return category(category.getId());
+    }
+
+    /**
+     * Sets the {@link Category} for the run.
+     *
+     * @param categoryId the category ID that the run is in
+     * @return this builder object
+     */
+    public SubmitRunRequest category(String categoryId) {
+        this.categoryId = categoryId;
+
+        return this;
+    }
+
+    /**
+     * Sets the {@link Level} for the run.
+     *
+     * @param level the level that the run is on
+     * @return this builder object
+     */
+    public SubmitRunRequest level(Level level) {
+        return level(level.getId());
+    }
+
+    /**
+     * Sets the {@link Level} for the run.
+     *
+     * @param levelId the level ID that the run is on
+     * @return this builder object
+     */
+    public SubmitRunRequest level(String levelId) {
+        this.levelId = levelId;
+
+        return this;
+    }
+
+    /**
+     * Sets the date that this run was played on.
+     *
+     * @param runDate the date this run was ran on
+     * @return this builder object
+     */
+    public SubmitRunRequest date(LocalDate runDate) {
+        this.date = runDate;
+
+        return this;
+    }
+
+    /**
+     * Sets the {@link Region} game version for the run.
+     *
+     * @param region the region of the game for the run
+     * @return this builder object
+     */
+    public SubmitRunRequest region(Region region) {
+        return region(region.getId());
+    }
+
+    /**
+     * Sets the {@link Region} game version for the run.
+     *
+     * @param regionId the region ID of the game for the run
+     * @return this builder object
+     */
+    public SubmitRunRequest region(String regionId) {
+        this.regionId = regionId;
+
+        return this;
+    }
+
+    /**
+     * Sets the {@link Platform} for the run.
+     *
+     * @param platform the platform that this run was played on
+     * @return this builder object
+     */
+    public SubmitRunRequest platform(Platform platform) {
+        return platform(platform.getId());
+    }
+
+    /**
+     * Sets the {@link Platform} for the run.
+     *
+     * @param platformId the platform ID that this run was played on
+     * @return this builder object
+     */
+    public SubmitRunRequest platform(String platformId) {
+        this.platformId = platformId;
+
+        return this;
+    }
+
+    /**
+     * Sets the run to be immediately verified when submitted.
+     * <br>
+     * Requires permissions to verify runs for the leaderboard that the run is being submitted to.
+     *
+     * @return this builder object
+     */
+    public SubmitRunRequest verified() {
+        this.verified = true;
+
+        return this;
+    }
+
+    /**
+     * Sets the realtime (RTA) time for the run.
+     *
+     * @param realTime a {@link Duration} with the RTA time
+     * @return this builder object
+     */
+    public SubmitRunRequest realTime(Duration realTime) {
+        times.put("realtime", realTime);
+
+        return this;
+    }
+
+    /**
+     * Sets the realtime (RTA) with loads removed time for the run.
+     *
+     * @param realTimeNoLoads a {@link Duration} with the RTA no loads time
+     * @return this builder object
+     */
+    public SubmitRunRequest realTimeNoLoads(Duration realTimeNoLoads) {
+        times.put("realtime_noloads", realTimeNoLoads);
+
+        return this;
+    }
+
+    /**
+     * Sets the ingame time (IGT) for the run.
+     *
+     * @param ingameTime a {@link Duration} with the ingame time
+     * @return this builder object
+     */
+    public SubmitRunRequest ingameTime(Duration ingameTime) {
+        times.put("ingame", ingameTime);
+
+        return this;
+    }
+
+    /**
+     * Adds a {@link User} that participated in the run.
+     *
+     * @param user a user that is a player in the run
+     * @return this builder object
+     */
+    public SubmitRunRequest userPlayer(User user) {
+        return userPlayer(user.getId());
+    }
+
+    /**
+     * Adds a {@link User} that participated in the run.
+     *
+     * @param userId the ID of a user that is a player in the run
+     * @return this builder object
+     */
+    public SubmitRunRequest userPlayer(String userId) {
+        players.put(userId, "user");
+
+        return this;
+    }
+
+    /**
+     * Adds a {@link Guest} that participated in the run.
+     *
+     * @param guest a guest that is a player in the run
+     * @return this builder object
+     */
+    public SubmitRunRequest guestPlayer(Guest guest) {
+        return guestPlayer(guest.getName());
+    }
+
+    /**
+     * Adds a {@link Guest} that participated in the run.
+     *
+     * @param guestName the name of a guest that is a player in the run
+     * @return this builder object
+     */
+    public SubmitRunRequest guestPlayer(String guestName) {
+        players.put(guestName, "guest");
+
+        return this;
+    }
+
+    /**
+     * Sets whether the run was played on an emulator.
+     *
+     * @param isEmulated whether an emulator was used
+     * @return this builder object
+     */
+    public SubmitRunRequest emulated(boolean isEmulated) {
+        this.isEmulated = isEmulated;
+
+        return this;
+    }
+
+    /**
+     * Sets the video URL for the run.
+     *
+     * @param videoUrl a {@code String} with a URL to a video hosting site
+     * @return this builder object
+     */
+    public SubmitRunRequest video(String videoUrl) {
+        this.videoUrl = videoUrl;
+
+        return this;
+    }
+
+    /**
+     * Sets the comment/description for the run.
+     *
+     * @param comment a {@code String} with the custom comment
+     * @return this builder object
+     */
+    public SubmitRunRequest comment(String comment) {
+        this.comment = comment;
+
+        return this;
+    }
+
+    /**
+     * Sets the ID or URL for the splits.io run page.
+     *
+     * @param splitsIO a {@code String} with an ID or URL to a splits.io page
+     * @return this builder object
+     */
+    public SubmitRunRequest splitsIO(String splitsIO) {
+        this.splitsIO = splitsIO;
+
+        return this;
+    }
+
+    /**
+     * Sets the value for a {@link Variable} with a predefined value ID.
+     *
+     * @param variable the variable to set for the run
+     * @param valueId the value ID to set for the variable
+     * @return this builder object
+     */
+    public SubmitRunRequest variable(Variable variable, String valueId) {
+        return variable(variable.getId(), valueId);
+    }
+
+    /**
+     * Sets the value for a {@link Variable} with a predefined value ID.
+     *
+     * @param variableId the variable ID to set for the run
+     * @param valueId the value ID to set for the variable
+     * @return this builder object
+     */
+    public SubmitRunRequest variable(String variableId, String valueId) {
+        this.variables.put(variableId, new RunVariable(VariableType.PREDEFINED, valueId));
+
+        return this;
+    }
+
+    /**
+     * Sets the value for a {@link Variable} with custom user defined text.
+     *
+     * @param variable the variable to set for the run
+     * @param valueText the value to set for the variable
+     * @return this builder object
+     */
+    public SubmitRunRequest customVariable(Variable variable, String valueText) {
+        return customVariable(variable.getId(), valueText);
+    }
+
+    /**
+     * Sets the value for a {@link Variable} with custom user defined text.
+     *
+     * @param variableId the variable ID to set for the run
+     * @param valueText the value to set for the variable
+     * @return this builder object
+     */
+    public SubmitRunRequest customVariable(String variableId, String valueText) {
+        this.variables.put(variableId, new RunVariable(VariableType.USER_DEFINED, valueText));
+
+        return this;
+    }
 
     @Override
     protected Run parse(JSONObject data) {
         return new Run(data);
+    }
+
+    @Override
+    protected JSONElement buildBody() throws InvalidBuilderStateException {
+        if(categoryId == null) {
+            throw new InvalidBuilderStateException("Missing required category");
+        }
+        if(platformId == null) {
+            throw new InvalidBuilderStateException("Missing required platform");
+        }
+        if(times.isEmpty()) {
+            throw new InvalidBuilderStateException("Missing run time, must have at least one set");
+        }
+
+        JSONObject runNode = new JSONObject();
+        runNode.put("category", categoryId);
+        if(levelId != null) {
+            runNode.put("level", levelId);
+        }
+        if(date != null) {
+            runNode.put("date", date);
+        }
+        if(regionId != null) {
+            runNode.put("region", regionId);
+        }
+        runNode.put("platform", platformId);
+        runNode.put("verified", verified);
+
+        JSONObject timesNode = new JSONObject();
+        for(Map.Entry<String, Duration> entry : times.entrySet()) {
+            Duration duration = entry.getValue();
+            double seconds = duration.toSeconds();
+            double milliseconds = duration.toMillisPart();
+
+            double time = seconds + (milliseconds / 1000);
+
+            timesNode.put(entry.getKey(), time);
+        }
+
+        runNode.put("times", timesNode);
+        if(!players.isEmpty()) {
+            JSONArray playersNode = new JSONArray();
+
+            for(Map.Entry<String, String> entry : players.entrySet()) {
+                JSONObject playerNode = new JSONObject();
+
+                String id = entry.getKey();
+                String type = entry.getValue();
+
+                playerNode.put("rel", type);
+
+                String idKeyName;
+                if(type.equals("user")) {
+                    idKeyName = "id";
+                } else {
+                    idKeyName = "name";
+                }
+
+                playerNode.put(idKeyName, id);
+                playersNode.put(playerNode);
+            }
+
+            runNode.put("players", playersNode);
+        }
+        runNode.put("emulated", isEmulated);
+        if(videoUrl != null) {
+            runNode.put("video", videoUrl);
+        }
+        if(comment != null) {
+            runNode.put("comment", comment);
+        }
+        if(splitsIO != null) {
+            runNode.put("splitsio", splitsIO);
+        }
+        JSONObject variablesNode = new JSONObject();
+        for(Map.Entry<String, RunVariable> entry : variables.entrySet()) {
+            JSONObject variableNode = new JSONObject();
+
+            if(entry.getValue().type == VariableType.PREDEFINED) {
+                variableNode.put("type", "pre-defined");
+            } else {
+                variableNode.put("type", "user-defined");
+            }
+            variableNode.put("value", entry.getValue().value);
+
+            variablesNode.put(entry.getKey(), variableNode);
+        }
+        runNode.put("variables", variablesNode);
+
+        JSONObject rootNode = new JSONObject();
+        rootNode.put("run", runNode);
+
+        return rootNode;
     }
 }

--- a/src/main/java/com/github/treescrub/spedran/api/request/user/ProfileRequest.java
+++ b/src/main/java/com/github/treescrub/spedran/api/request/user/ProfileRequest.java
@@ -1,0 +1,17 @@
+package com.github.treescrub.spedran.api.request.user;
+
+import com.github.treescrub.spedran.api.request.SingleResourceRequest;
+import com.github.treescrub.spedran.data.user.User;
+import kong.unirest.HttpMethod;
+import kong.unirest.json.JSONObject;
+
+public class ProfileRequest extends SingleResourceRequest<User> {
+    public ProfileRequest() {
+        super(HttpMethod.GET, "profile");
+    }
+
+    @Override
+    protected User parse(JSONObject data) {
+        return new User(data.getJSONObject("data"));
+    }
+}

--- a/src/main/java/com/github/treescrub/spedran/data/notification/Notification.java
+++ b/src/main/java/com/github/treescrub/spedran/data/notification/Notification.java
@@ -1,0 +1,70 @@
+package com.github.treescrub.spedran.data.notification;
+
+import com.github.treescrub.spedran.data.IdentifiableResource;
+import com.github.treescrub.spedran.data.Link;
+import kong.unirest.json.JSONObject;
+
+import java.time.Instant;
+
+public class Notification extends IdentifiableResource {
+    private final Instant creationTime;
+    private final NotificationStatus status;
+    private final String notificationText;
+    private final Link itemLink;
+
+    public Notification(JSONObject data) {
+        super(data);
+
+        creationTime = Instant.parse(data.getString("created"));
+        status = NotificationStatus.valueOf(data.getString("status").toUpperCase());
+        notificationText = data.getString("text");
+        itemLink = new Link(data.getJSONObject("item"));
+    }
+
+    /**
+     * Gets the {@link Instant} that the notification was created.
+     *
+     * @return an {@code Instant} with the time of notification creation
+     */
+    public Instant getCreationTime() {
+        return creationTime;
+    }
+
+    /**
+     * Gets the current {@link NotificationStatus} of the notification.
+     *
+     * @return a {@code NotificationStatus}
+     */
+    public NotificationStatus getStatus() {
+        return status;
+    }
+
+    /**
+     * Gets the text of the notification.
+     *
+     * @return a {@code String} with the text
+     */
+    public String getNotificationText() {
+        return notificationText;
+    }
+
+    /**
+     * Gets a {@link Link} with the type of notification and URL of the relevant page.
+     * <p>
+     *  {@link Link#getRelation()} will be one of:
+     *  <ul>
+     *     <li>{@code "post"} - Forum post created, a user liked a forum post, or a user commented on a run</li>
+     *     <li>{@code "run"} - New run for verification, a run status changed, or a user beat WR</li>
+     *     <li>{@code "game"} - Game request approved or denied</li>
+     *     <li>{@code "guide"} - Guide posted or updated</li>
+     *     <li>{@code "thread"} - Created new forum thread</li>
+     *     <li>An empty {@code Optional} - News post created (possibly other scenarios)</li>
+     *  </ul>
+     * </p>
+     *
+     * @return a {@code Link} for the relevant page
+     */
+    public Link getItemLink() {
+        return itemLink;
+    }
+}

--- a/src/main/java/com/github/treescrub/spedran/data/notification/Notification.java
+++ b/src/main/java/com/github/treescrub/spedran/data/notification/Notification.java
@@ -50,17 +50,16 @@ public class Notification extends IdentifiableResource {
 
     /**
      * Gets a {@link Link} with the type of notification and URL of the relevant page.
-     * <p>
-     *  {@link Link#getRelation()} will be one of:
-     *  <ul>
-     *     <li>{@code "post"} - Forum post created, a user liked a forum post, or a user commented on a run</li>
-     *     <li>{@code "run"} - New run for verification, a run status changed, or a user beat WR</li>
-     *     <li>{@code "game"} - Game request approved or denied</li>
-     *     <li>{@code "guide"} - Guide posted or updated</li>
-     *     <li>{@code "thread"} - Created new forum thread</li>
-     *     <li>An empty {@code Optional} - News post created (possibly other scenarios)</li>
-     *  </ul>
-     * </p>
+     * <br><br>
+     * {@link Link#getRelation()} will be one of:
+     * <ul>
+     *    <li>{@code "post"} - Forum post created, a user liked a forum post, or a user commented on a run</li>
+     *    <li>{@code "run"} - New run for verification, a run status changed, or a user beat WR</li>
+     *    <li>{@code "game"} - Game request approved or denied</li>
+     *    <li>{@code "guide"} - Guide posted or updated</li>
+     *    <li>{@code "thread"} - Created new forum thread</li>
+     *    <li>An empty {@code Optional} - News post created (possibly other scenarios)</li>
+     * </ul>
      *
      * @return a {@code Link} for the relevant page
      */

--- a/src/main/java/com/github/treescrub/spedran/data/notification/NotificationStatus.java
+++ b/src/main/java/com/github/treescrub/spedran/data/notification/NotificationStatus.java
@@ -1,0 +1,15 @@
+package com.github.treescrub.spedran.data.notification;
+
+/**
+ * The read status of a notification.
+ */
+public enum NotificationStatus {
+    /**
+     * The notification has been marked as read.
+     */
+    READ,
+    /**
+     * The notification has not yet been marked as read.
+     */
+    UNREAD,
+}

--- a/src/main/java/com/github/treescrub/spedran/data/run/Run.java
+++ b/src/main/java/com/github/treescrub/spedran/data/run/Run.java
@@ -1,5 +1,6 @@
 package com.github.treescrub.spedran.data.run;
 
+import com.github.treescrub.spedran.api.Spedran;
 import com.github.treescrub.spedran.api.request.run.DeleteRunRequest;
 import com.github.treescrub.spedran.api.request.run.RunPlayersRequest;
 import com.github.treescrub.spedran.api.request.run.RunStatusRequest;
@@ -59,13 +60,14 @@ public class Run extends IdentifiableResource {
 
     /**
      * Returns a request builder that allows deletion of this run from SRC.
-     * Requires an API key with sufficient permissions to delete runs, or API key of run owner.
+     * Requires a set API key with sufficient permissions to delete runs, or API key of run owner.
      *
-     * @param apiKey SRC API key
      * @return a request builder to delete this run
+     *
+     * @see Spedran#setApiKey(String)
      */
-    public DeleteRunRequest delete(String apiKey) {
-        return new DeleteRunRequest(this, apiKey);
+    public DeleteRunRequest delete() {
+        return new DeleteRunRequest(this);
     }
 
     /**
@@ -102,7 +104,7 @@ public class Run extends IdentifiableResource {
      * @return the id of the game this run belongs to
      *
      * @see com.github.treescrub.spedran.data.game.Game
-     * @see com.github.treescrub.spedran.api.Spedran#getGame(String)
+     * @see Spedran#getGame(String)
      */
     public String getGame() {
         return game;
@@ -115,7 +117,7 @@ public class Run extends IdentifiableResource {
      * @return an {@code Optional} with the ID of this run's level
      *
      * @see com.github.treescrub.spedran.data.Level
-     * @see com.github.treescrub.spedran.api.Spedran#getLevel(String)
+     * @see Spedran#getLevel(String)
      */
     public Optional<String> getLevel() {
         return Optional.ofNullable(level);
@@ -127,7 +129,7 @@ public class Run extends IdentifiableResource {
      * @return the ID of this run's category
      *
      * @see com.github.treescrub.spedran.data.category.Category
-     * @see com.github.treescrub.spedran.api.Spedran#getCategory(String)
+     * @see Spedran#getCategory(String)
      */
     public String getCategory() {
         return category;

--- a/src/main/java/com/github/treescrub/spedran/data/run/Run.java
+++ b/src/main/java/com/github/treescrub/spedran/data/run/Run.java
@@ -59,10 +59,11 @@ public class Run extends IdentifiableResource {
     }
 
     /**
-     * Returns a request builder that allows deletion of this run from SRC.
+     * Gets a new {@link DeleteRunRequest} builder to delete this run from SRC.
+     * <br>
      * Requires a set API key with sufficient permissions to delete runs, or API key of run owner.
      *
-     * @return a request builder to delete this run
+     * @return a {@code DeleteRunRequest} builder
      *
      * @see Spedran#setApiKey(String)
      */
@@ -71,19 +72,22 @@ public class Run extends IdentifiableResource {
     }
 
     /**
-     * Returns a request builder to set the players on this run.
+     * Gets a new {@link RunPlayersRequest} builder to set the players on this run.
+     * <br>
+     * Requires a set API key with sufficient permissions to change the players on this run.
      *
-     * @return a request builder to set players
+     * @return a {@code RunPlayersRequest} builder
      */
     public RunPlayersRequest setPlayers() {
         return new RunPlayersRequest(this);
     }
 
     /**
-     * Returns a request builder to change the status of this run.
+     * Gets a new {@link RunStatusRequest} builder to change the status of this run.
+     * <br>
      * Requires an API key with sufficient permissions to reject/verify runs.
      *
-     * @return
+     * @return a request builder to set the status
      */
     public RunStatusRequest setStatus() {
         return new RunStatusRequest(this);

--- a/src/main/java/com/github/treescrub/spedran/data/run/SubmissionStatus.java
+++ b/src/main/java/com/github/treescrub/spedran/data/run/SubmissionStatus.java
@@ -19,4 +19,9 @@ public enum SubmissionStatus {
      * The run was verified by a verifier.
      */
     VERIFIED,
+    ;
+
+    public String toAPIName() {
+        return this.name().toLowerCase();
+    }
 }

--- a/src/main/java/com/github/treescrub/spedran/requests/Requests.java
+++ b/src/main/java/com/github/treescrub/spedran/requests/Requests.java
@@ -25,8 +25,8 @@ public class Requests {
         unirestInstance.config().interceptor(new LoggingInterceptor());
     }
 
-    public static HttpRequest<?> request(HttpMethod method, String url) {
-        HttpRequest<?> httpRequest = unirestInstance.request(method.name(), url);
+    public static HttpRequestWithBody request(HttpMethod method, String url) {
+        HttpRequestWithBody httpRequest = unirestInstance.request(method.name(), url);
         if(key != null) {
             httpRequest.header("X-Api-Key", key);
         }


### PR DESCRIPTION
Implemented request builders to delete a run, change players for a run, set the status of a run, submit a run, and get the authenticated user's profile/notifications.