### PR TITLE
Rename "get*" request methods to "fetch*"

### DIFF
--- a/src/main/java/com/treescrub/spedran/data/Category.java
+++ b/src/main/java/com/treescrub/spedran/data/Category.java
@@ -36,7 +36,7 @@ public class Category extends IdentifiableNamedResource {
      * @return a {@code RunsRequest} builder
      */
     @SuppressWarnings("unused")
-    public RunsRequest getRuns() {
+    public RunsRequest fetchRuns() {
         return Spedran.getRuns().category(this);
     }
 
@@ -46,7 +46,7 @@ public class Category extends IdentifiableNamedResource {
      * @return a {@code CategoryRecordsRequest} builder
      */
     @SuppressWarnings("unused")
-    public CategoryRecordsRequest getRecords() {
+    public CategoryRecordsRequest fetchRecords() {
         return Spedran.getCategoryRecords(id);
     }
 
@@ -56,7 +56,7 @@ public class Category extends IdentifiableNamedResource {
      * @return a {@code CategoryVariablesRequest} builder
      */
     @SuppressWarnings("unused")
-    public CategoryVariablesRequest getVariables() {
+    public CategoryVariablesRequest fetchVariables() {
         return Spedran.getCategoryVariables(id);
     }
 

--- a/src/main/java/com/treescrub/spedran/data/Developer.java
+++ b/src/main/java/com/treescrub/spedran/data/Developer.java
@@ -21,7 +21,7 @@ public class Developer extends IdentifiableNamedResource {
      * @return a {@code GamesRequest} builder
      */
     @SuppressWarnings("unused")
-    public GamesRequest getGames() {
+    public GamesRequest fetchGames() {
         return Spedran.getGames().developer(this);
     }
 

--- a/src/main/java/com/treescrub/spedran/data/Engine.java
+++ b/src/main/java/com/treescrub/spedran/data/Engine.java
@@ -21,7 +21,7 @@ public class Engine extends IdentifiableNamedResource {
      * @return a {@code GamesRequest} builder
      */
     @SuppressWarnings("unused")
-    public GamesRequest getGames() {
+    public GamesRequest fetchGames() {
         return Spedran.getGames().engine(this);
     }
 

--- a/src/main/java/com/treescrub/spedran/data/Game.java
+++ b/src/main/java/com/treescrub/spedran/data/Game.java
@@ -68,7 +68,7 @@ public class Game extends IdentifiableResource {
      * @return a {@code RunsRequest} builder
      */
     @SuppressWarnings("unused")
-    public RunsRequest getRuns() {
+    public RunsRequest fetchRuns() {
         return Spedran.getRuns().game(this);
     }
 
@@ -78,7 +78,7 @@ public class Game extends IdentifiableResource {
      * @return a {@code GameCategoriesRequest} builder
      */
     @SuppressWarnings("unused")
-    public GameCategoriesRequest getCategories() {
+    public GameCategoriesRequest fetchCategories() {
         return Spedran.getGameCategories(id);
     }
 
@@ -88,7 +88,7 @@ public class Game extends IdentifiableResource {
      * @return a {@code GameLevelsRequest} builder
      */
     @SuppressWarnings("unused")
-    public GameLevelsRequest getLevels() {
+    public GameLevelsRequest fetchLevels() {
         return Spedran.getGameLevels(id);
     }
 
@@ -98,7 +98,7 @@ public class Game extends IdentifiableResource {
      * @return a {@code GameRecordsRequest} builder
      */
     @SuppressWarnings("unused")
-    public GameRecordsRequest getRecords() {
+    public GameRecordsRequest fetchRecords() {
         return Spedran.getGameRecords(id);
     }
 
@@ -108,7 +108,7 @@ public class Game extends IdentifiableResource {
      * @return a {@code GameRomhacksRequest} builder
      */
     @SuppressWarnings("unused")
-    public GameRomhacksRequest getRomhacks() {
+    public GameRomhacksRequest fetchRomhacks() {
         return Spedran.getGameRomhacks(id);
     }
 
@@ -118,7 +118,7 @@ public class Game extends IdentifiableResource {
      * @return a {@code GameVariablesRequest} builder
      */
     @SuppressWarnings("unused")
-    public GameVariablesRequest getVariables() {
+    public GameVariablesRequest fetchVariables() {
         return Spedran.getGameVariables(id);
     }
 

--- a/src/main/java/com/treescrub/spedran/data/Gametype.java
+++ b/src/main/java/com/treescrub/spedran/data/Gametype.java
@@ -23,7 +23,7 @@ public class Gametype extends IdentifiableNamedResource {
      * @return a {@code GamesRequest} builder
      */
     @SuppressWarnings("unused")
-    public GamesRequest getGames() {
+    public GamesRequest fetchGames() {
         return Spedran.getGames().gameType(this);
     }
 

--- a/src/main/java/com/treescrub/spedran/data/Genre.java
+++ b/src/main/java/com/treescrub/spedran/data/Genre.java
@@ -23,7 +23,7 @@ public class Genre extends IdentifiableNamedResource {
      * @return a {@code GamesRequest} builder
      */
     @SuppressWarnings("unused")
-    public GamesRequest getGames() {
+    public GamesRequest fetchGames() {
         return Spedran.getGames().genre(this);
     }
 

--- a/src/main/java/com/treescrub/spedran/data/Guest.java
+++ b/src/main/java/com/treescrub/spedran/data/Guest.java
@@ -27,7 +27,7 @@ public class Guest extends Resource {
      *
      * @return a {@code RunsRequest} builder
      */
-    public RunsRequest getRuns() {
+    public RunsRequest fetchRuns() {
         return Spedran.getRuns().guest(this);
     }
 

--- a/src/main/java/com/treescrub/spedran/data/Level.java
+++ b/src/main/java/com/treescrub/spedran/data/Level.java
@@ -31,7 +31,7 @@ public class Level extends IdentifiableNamedResource {
      * @return a {@code RunsRequest} builder
      */
     @SuppressWarnings("unused")
-    public RunsRequest getRuns() {
+    public RunsRequest fetchRuns() {
         return Spedran.getRuns().level(this);
     }
 
@@ -41,7 +41,7 @@ public class Level extends IdentifiableNamedResource {
      * @return a {@code LevelCategoriesRequest} builder
      */
     @SuppressWarnings("unused")
-    public LevelCategoriesRequest getCategories() {
+    public LevelCategoriesRequest fetchCategories() {
         return Spedran.getLevelCategories(id);
     }
 
@@ -51,7 +51,7 @@ public class Level extends IdentifiableNamedResource {
      * @return a {@code LevelRecordsRequest} builder
      */
     @SuppressWarnings("unused")
-    public LevelRecordsRequest getRecords() {
+    public LevelRecordsRequest fetchRecords() {
         return new LevelRecordsRequest(this);
     }
 
@@ -61,7 +61,7 @@ public class Level extends IdentifiableNamedResource {
      * @return a {@code LevelVariablesRequest} builder
      */
     @SuppressWarnings("unused")
-    public LevelVariablesRequest getVariables() {
+    public LevelVariablesRequest fetchVariables() {
         return new LevelVariablesRequest(this);
     }
 

--- a/src/main/java/com/treescrub/spedran/data/Platform.java
+++ b/src/main/java/com/treescrub/spedran/data/Platform.java
@@ -27,7 +27,7 @@ public class Platform extends IdentifiableNamedResource {
      * @return a {@code GamesRequest} builder
      */
     @SuppressWarnings("unused")
-    public GamesRequest getGames() {
+    public GamesRequest fetchGames() {
         return Spedran.getGames().platform(this);
     }
 
@@ -37,7 +37,7 @@ public class Platform extends IdentifiableNamedResource {
      * @return a {@code RunsRequest} builder
      */
     @SuppressWarnings("unused")
-    public RunsRequest getRuns() {
+    public RunsRequest fetchRuns() {
         return Spedran.getRuns().platform(this);
     }
 

--- a/src/main/java/com/treescrub/spedran/data/Publisher.java
+++ b/src/main/java/com/treescrub/spedran/data/Publisher.java
@@ -23,7 +23,7 @@ public class Publisher extends IdentifiableNamedResource {
      * @return a {@code GamesRequest} builder
      */
     @SuppressWarnings("unused")
-    public GamesRequest getGames() {
+    public GamesRequest fetchGames() {
         return Spedran.getGames().publisher(this);
     }
 

--- a/src/main/java/com/treescrub/spedran/data/Region.java
+++ b/src/main/java/com/treescrub/spedran/data/Region.java
@@ -26,7 +26,7 @@ public class Region extends IdentifiableNamedResource {
      * @return a {@code GamesRequest} builder
      */
     @SuppressWarnings("unused")
-    public GamesRequest getGames() {
+    public GamesRequest fetchGames() {
         return Spedran.getGames().region(this);
     }
 
@@ -36,7 +36,7 @@ public class Region extends IdentifiableNamedResource {
      * @return a {@code RunsRequest} builder
      */
     @SuppressWarnings("unused")
-    public RunsRequest getRuns() {
+    public RunsRequest fetchRuns() {
         return Spedran.getRuns().region(this);
     }
 

--- a/src/main/java/com/treescrub/spedran/data/Series.java
+++ b/src/main/java/com/treescrub/spedran/data/Series.java
@@ -55,7 +55,7 @@ public class Series extends IdentifiableResource {
      * @return a {@code SeriesGamesRequest} builder
      */
     @SuppressWarnings("unused")
-    public SeriesGamesRequest getGames() {
+    public SeriesGamesRequest fetchGames() {
         return Spedran.getSeriesGames(id);
     }
 

--- a/src/main/java/com/treescrub/spedran/data/User.java
+++ b/src/main/java/com/treescrub/spedran/data/User.java
@@ -55,7 +55,7 @@ public class User extends IdentifiableResource {
      * @return a {@code RunsRequest} builder
      */
     @SuppressWarnings("unused")
-    public RunsRequest getRuns() {
+    public RunsRequest fetchRuns() {
         return Spedran.getRuns().user(this);
     }
 
@@ -65,7 +65,7 @@ public class User extends IdentifiableResource {
      * @return a {@code GamesRequest} builder
      */
     @SuppressWarnings("unused")
-    public GamesRequest getGamesModerated() {
+    public GamesRequest fetchGamesModerated() {
         return Spedran.getGames().moderator(this);
     }
 
@@ -75,7 +75,7 @@ public class User extends IdentifiableResource {
      * @return a {@code UserPBsRequest} builder
      */
     @SuppressWarnings("unused")
-    public UserPBsRequest getPersonalBests() {
+    public UserPBsRequest fetchPersonalBests() {
         return Spedran.getUserPBs(id);
     }
 


### PR DESCRIPTION
Renames most "get*" request methods to "fetch*" to make it more obvious that they will perform a request and to prevent naming conflicts of getters for embeddable resources in the future.